### PR TITLE
Add management repository monitoring to ecosystem-manager

### DIFF
--- a/ecosystem-manager.sh
+++ b/ecosystem-manager.sh
@@ -647,8 +647,8 @@ show_status() {
         printf "%s\t%s\t%s\t%s\t%s\t%s\n" "----------" "------" "-------" "-----------" "---" "------"
     else
         # Compact format: fixed width, with truncation
-        printf "%-26s %-27s %-8s %-20s %-8s %-8s\n" "Repository" "Branch" "Changes" "Last Commit" "PRs" "Issues"
-        printf "%-26s %-27s %-8s %-20s %-8s %-8s\n" "----------" "------" "-------" "-----------" "---" "------"
+        printf "%-26s %-27s %-8s %-22s %-8s %-8s\n" "Repository" "Branch" "Changes" "Last Commit" "PRs" "Issues"
+        printf "%-26s %-27s %-8s %-22s %-8s %-8s\n" "----------" "------" "-------" "-----------" "---" "------"
     fi
     
     for repo in "${REPOS[@]}"; do
@@ -717,15 +717,15 @@ show_status() {
                 # Short format with fixed width columns
                 if [ "$changes" -gt 0 ]; then
                     if [ "$urgent" -gt 0 ]; then
-                        printf "%-26s %-27s ${YELLOW}%-8s${NC} %-20s %-8s ${RED}%-8s${NC}\n" "$repo_display" "$branch_display" "$changes" "$last_commit" "$pr_info" "$issue_info"
+                        printf "%-26s %-27s ${YELLOW}%-8s${NC} %-22s %-8s ${RED}%-8s${NC}\n" "$repo_display" "$branch_display" "$changes" "$last_commit" "$pr_info" "$issue_info"
                     else
-                        printf "%-26s %-27s ${YELLOW}%-8s${NC} %-20s %-8s %-8s\n" "$repo_display" "$branch_display" "$changes" "$last_commit" "$pr_info" "$issue_info"
+                        printf "%-26s %-27s ${YELLOW}%-8s${NC} %-22s %-8s %-8s\n" "$repo_display" "$branch_display" "$changes" "$last_commit" "$pr_info" "$issue_info"
                     fi
                 else
                     if [ "$urgent" -gt 0 ]; then
-                        printf "%-26s %-27s ${GREEN}%-8s${NC} %-20s %-8s ${RED}%-8s${NC}\n" "$repo_display" "$branch_display" "clean" "$last_commit" "$pr_info" "$issue_info"
+                        printf "%-26s %-27s ${GREEN}%-8s${NC} %-22s %-8s ${RED}%-8s${NC}\n" "$repo_display" "$branch_display" "clean" "$last_commit" "$pr_info" "$issue_info"
                     else
-                        printf "%-26s %-27s ${GREEN}%-8s${NC} %-20s %-8s %-8s\n" "$repo_display" "$branch_display" "clean" "$last_commit" "$pr_info" "$issue_info"
+                        printf "%-26s %-27s ${GREEN}%-8s${NC} %-22s %-8s %-8s\n" "$repo_display" "$branch_display" "clean" "$last_commit" "$pr_info" "$issue_info"
                     fi
                 fi
             fi
@@ -751,7 +751,7 @@ show_status() {
             if [ "$LONG_FORMAT" = "true" ]; then
                 printf "%s\t${RED}%s${NC}\t%s\t%s\t%s\t%s\n" "$repo_display" "missing" "-" "-" "-" "-"
             else
-                printf "%-26s ${RED}%-27s${NC} %-8s %-20s %-8s %-8s\n" "$repo_display" "missing" "-" "-" "-" "-"
+                printf "%-26s ${RED}%-27s${NC} %-8s %-22s %-8s %-8s\n" "$repo_display" "missing" "-" "-" "-" "-"
             fi
         fi
     done


### PR DESCRIPTION
## Summary
- ecosystem-manager.sh の監視対象に管理リポジトリ（"."）を追加
- 表示名を "latex-ecosystem" に変換する機能を実装
- "Last Commit" 列の幅を22文字に調整

## Changes
- REPOS配列に "." を追加
- get_repo_display_name() 関数を追加（"." → "latex-ecosystem" 変換）
- repo_exists(), get_current_branch(), get_repo_status() などの関数で現在ディレクトリに対応
- GitHub API呼び出し機能で現在ディレクトリに対応
- 表示フォーマットの列幅調整（Last Commit: 20 → 22文字）

## Test Plan
- [x] ./ecosystem-manager.sh status でlatex-ecosystemが表示されることを確認
- [x] 現在のディレクトリの git 情報が正しく取得されることを確認
- [x] GitHub API 呼び出しが正常に動作することを確認
- [x] 列幅調整により表示が改善されることを確認