### PR TITLE
Add poster-template to LaTeX ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -15,6 +15,7 @@ This document describes the architecture and management strategy for the thesis-
 - **wr-template**: Weekly report template
 - **latex-template**: Basic LaTeX template
 - **sotsuron-report-template**: Report template for thesis work
+- **poster-template**: Academic poster template (A0 size, conference presentations)
 
 ### Management & Automation
 - **thesis-management-tools**: Administrative tools and documentation for thesis supervision
@@ -36,7 +37,8 @@ latex-environment (DevContainer Template)
 ├── ise-report-template (HTML-based quality-focused)
 ├── wr-template
 ├── latex-template
-└── sotsuron-report-template
+├── sotsuron-report-template
+└── poster-template
 
 Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)
@@ -55,6 +57,7 @@ Supporting Infrastructure:
 | latex-template | Latest | Auto-updated via aldc | No manual updates needed |
 | wr-template | Latest | Auto-updated via aldc | No manual updates needed |
 | sotsuron-report-template | Latest | Auto-updated via aldc | No manual updates needed |
+| poster-template | Latest | Auto-updated via aldc | No manual updates needed |
 | latex-release-action | v2.2.0 | All templates | Per feature |
 | aldc | Latest | latex-environment:release | No updates needed |
 
@@ -105,18 +108,21 @@ Supporting Infrastructure:
 - **ise-report-template**: HTML-based reports with web accessibility and quality automation
 - **wr-template**: Weekly progress reports with structured formatting
 - **latex-template**: Minimal LaTeX setup for general academic documents
+- **poster-template**: A0-sized academic posters using tikzposter with LuaLaTeX
 
 ### Quality Management Approaches
 - **ise-report-template**: Comprehensive quality pipeline (HTML5 validation, accessibility checks, textlint for Japanese)
 - **sotsuron-template**: Academic writing standards with citation management
 - **wr-template**: Structured progress tracking with consistent formatting
 - **latex-template**: Basic LaTeX quality assurance
+- **poster-template**: Automated PDF generation with visual design validation
 
 ### Target Audiences
 - **ise-report-template**: Information Science Exercise students (HTML proficiency development)
 - **sotsuron-template**: Undergraduate/graduate thesis students (research document preparation)
 - **wr-template**: Research students and faculty (progress tracking)
 - **latex-template**: General academic users (basic LaTeX needs)
+- **poster-template**: Researchers presenting at conferences and symposiums
 
 ## Cross-Repository Standards
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ latex-ecosystem/
 ├── docs/                     # Detailed documentation
 │
 ├── texlive-ja-textlint/      # Independent Git repository
-├── latex-environment/        # Independent Git repository  
+├── latex-environment/        # Independent Git repository
 ├── sotsuron-template/        # Independent Git repository
 ├── thesis-management-tools/  # Independent Git repository
 ├── latex-release-action/     # Independent Git repository
@@ -22,7 +22,8 @@ latex-ecosystem/
 ├── aldc/                     # Independent Git repository
 ├── wr-template/              # Independent Git repository
 ├── latex-template/           # Independent Git repository
-└── sotsuron-report-template/ # Independent Git repository
+├── sotsuron-report-template/ # Independent Git repository
+└── poster-template/          # Independent Git repository
 ```
 
 ## Prerequisites
@@ -165,7 +166,8 @@ latex-environment (DevContainer Template)
 ├── sotsuron-template (Student Templates)
 ├── wr-template
 ├── latex-template
-└── sotsuron-report-template
+├── sotsuron-report-template
+└── poster-template
 
 Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)


### PR DESCRIPTION
## Summary

Add poster-template repository to the LaTeX ecosystem documentation.

## Changes

### ECOSYSTEM.md
- Added `poster-template` to Templates & Tools section
- Updated Dependency Matrix to include poster-template
- Added to Version Compatibility table
- Updated Template Specialization sections:
  - **Document Format Focus**: A0-sized academic posters using tikzposter with LuaLaTeX
  - **Quality Management Approaches**: Automated PDF generation with visual design validation
  - **Target Audiences**: Researchers presenting at conferences and symposiums

### README.md
- Added `poster-template` to repository structure
- Updated Dependency Flow diagram

## Related Repository

The new poster-template repository: https://github.com/smkwlab/poster-template

## Test Plan

- [x] Verify ECOSYSTEM.md formatting and completeness
- [x] Verify README.md structure consistency
- [x] Confirm poster-template repository exists and is accessible
- [x] Check that all documentation links are valid