### PR TITLE
Pin ecosystem docs setup URL to v1 moving tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,10 +100,10 @@ This directory contains multiple **independent Git repositories**:
 ### Student Repository Creation
 ```bash
 # Create student thesis repository (automated)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash thesis
 
 # Create weekly report repository
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup-wr.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash wr
 ```
 
 ### Student Progress Monitoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,65 @@ thesis-monitor status --verbose
 2. Use that repository's CLAUDE.md for context
 3. Follow that repository's development workflow
 
+### Updating Workflow Files in Student Repositories
+
+**IMPORTANT**: Student repositories use draft-to-draft PR workflow (`2nd-draft` → `1st-draft` → `0th-draft` → `main`). When updating workflow files, you must propagate changes through the branch hierarchy to avoid triggering GitHub Actions security restrictions.
+
+#### Why This Matters
+
+- `pull_request` event workflows use the **base branch's** workflow file
+- If workflow changes appear in PR diffs, GitHub may skip workflow execution for security
+- Each draft branch needs the updated workflow for proper PR handling
+
+#### Correct Procedure
+
+```bash
+# 1. Update main branch first
+git checkout main
+# Make workflow changes
+git add .github/workflows/
+git commit -m "Update workflow files"
+git push
+
+# 2. Propagate to each draft branch via merge (preserves commit history)
+git checkout 0th-draft
+git merge main -m "Merge workflow updates from main"
+git push
+
+git checkout 1st-draft
+git merge 0th-draft -m "Merge workflow updates from 0th-draft"
+git push
+
+git checkout 2nd-draft
+git merge 1st-draft -m "Merge workflow updates from 1st-draft"
+git push
+
+# Continue for 3rd-draft, etc. if they exist
+```
+
+#### What NOT To Do
+
+❌ **Do not push identical changes independently to each branch**:
+```bash
+# WRONG - creates separate commit histories
+git checkout 0th-draft && git add . && git commit && git push
+git checkout 1st-draft && git add . && git commit && git push
+git checkout 2nd-draft && git add . && git commit && git push
+```
+
+This causes:
+- PR diffs to include workflow file changes (even if content is identical)
+- GitHub Actions security restrictions to skip `pull_request` triggered workflows
+- Notification emails and other PR-triggered actions to fail
+
+#### Verification
+
+After updating, verify that existing PRs don't show workflow file changes:
+```bash
+gh pr diff <PR_NUMBER> --repo smkwlab/<repo> | grep -E "\.github/workflows"
+# Should return empty if done correctly
+```
+
 ## Security & Data Management
 
 - **Student Data Separation**: `thesis-student-registry` repository keeps student information separate for security

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Students should use the automated repository creation process:
 
 **Basic setup (zero dependencies required):**
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)"
 ```
 
 **With student ID specified:**
 ```bash
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)"
 ```
 
 ### For Faculty


### PR DESCRIPTION
## 概要

エコシステム管理リポジトリのドキュメント（`README.md`, `CLAUDE.md`）の学生向けリポジトリ作成コマンド例を、テンプレート群と同じく `v1` 移動タグ参照に統一します。

## 背景

- 学生が実行する各テンプレート README は既に `/v1/` へ移行・マージ済み（sotsuron / wr / ise / latex / poster）
- 依存先 `thesis-management-tools` の `v1` タグは [#440](https://github.com/smkwlab/thesis-management-tools/pull/440) で運用ドキュメント整備＋タグ解決の堅牢化が完了
- 管理リポのドキュメント例も学生向け案内と揃え、`/main/` → `/v1/` に更新

## 変更内容

- `README.md`: 学生向けセットアップ例2箇所を `/v1/` に変更
- `CLAUDE.md`:
  - 論文リポ作成例を `/v1/` に変更（`bash thesis` 引数も明記）
  - 週報作成例の **古い記述を修正**: 存在しない `setup-wr.sh`（main/v1 とも HTTP 404）＋ `/main/` を、現行の統合形式 `setup.sh ... bash wr`（`/v1/`）へ置換

## 確認

- `/v1/create-repo/setup.sh` は HTTP 200・`EMBEDDED_REF="v1.0.0"` を返すことを確認済み
- ルート管理リポ tracked ファイルに残存する `/main/...setup` 参照は無し

関連: smkwlab/thesis-management-tools#438