### PR TITLE
Document automated propagate-workflow command and standardize registry-manager path references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,25 +140,31 @@ thesis-monitor status --verbose
 
 #### Correct Procedure (Automated)
 
-Use the `propagate-workflow` command from `thesis-student-registry/registry-manager`.
+Use the `propagate-workflow` command of `registry-manager`, the Elixir escript
+located in the `registry_manager/` directory of the `thesis-student-registry`
+repository.
 
-> **Prerequisite**: Run these from the `thesis-student-registry` repository
-> checkout, in the directory where the `registry-manager` escript has been
-> built (e.g. `cd thesis-student-registry/registry_manager && mix escript.build`).
-> Otherwise `./registry-manager` will fail with "file not found".
+> **Prerequisite**: Build the escript first, then run the commands from the
+> `thesis-student-registry` repository checkout root:
+> ```bash
+> cd thesis-student-registry/registry_manager && mix escript.build && cd ..
+> ```
+> Otherwise `./registry_manager/registry-manager` will fail with "file not found".
 
 ```bash
+# (run from the thesis-student-registry checkout root)
+
 # Check what would be done (dry-run)
-./registry-manager propagate-workflow k22rs001-sotsuron --dry-run
+./registry_manager/registry-manager propagate-workflow k22rs001-sotsuron --dry-run
 
 # Propagate workflow updates for a single repository
-./registry-manager propagate-workflow k22rs001-sotsuron
+./registry_manager/registry-manager propagate-workflow k22rs001-sotsuron
 
 # Propagate to all thesis repositories at once
-./registry-manager propagate-workflow --all --type thesis
+./registry_manager/registry-manager propagate-workflow --all --type thesis
 
 # Check all repositories first
-./registry-manager propagate-workflow --all --type thesis --dry-run
+./registry_manager/registry-manager propagate-workflow --all --type thesis --dry-run
 ```
 
 #### Manual Procedure (if needed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,12 @@ thesis-monitor status --verbose
 
 #### Correct Procedure (Automated)
 
-Use the `propagate-workflow` command from `thesis-student-registry/registry-manager`:
+Use the `propagate-workflow` command from `thesis-student-registry/registry-manager`.
+
+> **Prerequisite**: Run these from the `thesis-student-registry` repository
+> checkout, in the directory where the `registry-manager` escript has been
+> built (e.g. `cd thesis-student-registry/registry_manager && mix escript.build`).
+> Otherwise `./registry-manager` will fail with "file not found".
 
 ```bash
 # Check what would be done (dry-run)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,25 @@ thesis-monitor status --verbose
 - If workflow changes appear in PR diffs, GitHub may skip workflow execution for security
 - Each draft branch needs the updated workflow for proper PR handling
 
-#### Correct Procedure
+#### Correct Procedure (Automated)
+
+Use the `propagate-workflow` command from `thesis-student-registry/registry-manager`:
+
+```bash
+# Check what would be done (dry-run)
+./registry-manager propagate-workflow k22rs001-sotsuron --dry-run
+
+# Propagate workflow updates for a single repository
+./registry-manager propagate-workflow k22rs001-sotsuron
+
+# Propagate to all thesis repositories at once
+./registry-manager propagate-workflow --all --type thesis
+
+# Check all repositories first
+./registry-manager propagate-workflow --all --type thesis --dry-run
+```
+
+#### Manual Procedure (if needed)
 
 ```bash
 # 1. Update main branch first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,10 @@ Use the `propagate-workflow` command of `registry-manager`, the Elixir escript
 located in the `registry_manager/` directory of the `thesis-student-registry`
 repository.
 
-> **Prerequisite**: Build the escript first, then run the commands from the
-> `thesis-student-registry` repository checkout root:
+> **Prerequisite**: All commands below are run from the `thesis-student-registry`
+> checkout root. Build the escript first (also from that root):
 > ```bash
-> cd thesis-student-registry/registry_manager && mix escript.build && cd ..
+> (cd registry_manager && mix escript.build)
 > ```
 > Otherwise `./registry_manager/registry-manager` will fail with "file not found".
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,9 @@ repository.
 > ```bash
 > (cd registry_manager && mix escript.build)
 > ```
-> Otherwise `./registry_manager/registry-manager` will fail with "file not found".
+> Without this build step the `./registry_manager/registry-manager` binary does
+> not exist yet, so the command fails (the exact wording varies by shell/OS, e.g.
+> "No such file or directory").
 
 ```bash
 # (run from the thesis-student-registry checkout root)

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -233,6 +233,14 @@ git checkout 0th-draft  # または指定されたブランチ
 4. Issue自動クローズ
 
 #### B. レジストリ管理
+
+> **前提**: 以下は `thesis-student-registry` チェックアウトのルートから実行する。
+> 初回はその前に escript をビルドしておく（ルートから）:
+> ```bash
+> (cd registry_manager && mix escript.build)
+> ```
+> 未ビルドだと `./registry_manager/registry-manager` が存在せずコマンドが失敗する。
+
 ```bash
 # 進捗監視（thesis-student-registry チェックアウトのルートから実行）
 ./registry_manager/registry-manager status

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -234,11 +234,11 @@ git checkout 0th-draft  # または指定されたブランチ
 
 #### B. レジストリ管理
 ```bash
-# 進捗監視
-./registry-manager status
+# 進捗監視（thesis-student-registry チェックアウトのルートから実行）
+./registry_manager/registry-manager status
 
 # 保護状況確認  
-./registry-manager status --show-protection
+./registry_manager/registry-manager status --show-protection
 ```
 
 ### 2. 品質管理システム
@@ -325,7 +325,7 @@ branches:
 - [学生作品例3](http://www-st.is.kyusan-u.ac.jp/~k22rs004/semi3a/)
 
 ### 管理ツール
-- [registry-manager](../thesis-student-registry/registry_manager_v3/)
+- [registry-manager](../thesis-student-registry/registry_manager/)
 - [thesis-management-tools](../thesis-management-tools/)
 
 ---


### PR DESCRIPTION
## 概要

学生リポジトリのワークフローファイル更新手順に、`registry-manager` の `propagate-workflow` コマンドを用いた**自動化手順**を追記します。既存の手動手順は `Manual Procedure (if needed)` として残します。あわせて、`registry-manager` の実行パス／ディレクトリ表記を関連ドキュメント間で統一します。

## 背景・経緯

- 本トピックの元 PR は #63（手動手順の追加）でしたが、その内容（コミット 41199b8 = 手動手順の基本版）は **PR #65 に相乗りする形で既に main へマージ済み**でした
  - 原因: #65 のブランチを、未push コミット 41199b8 を含むローカル main から作成してしまったため
- そのため #63 のブランチは main より遅れた不整合状態（v1化を含まない）となり、本 PR を**同期済み main から新規に作成**しています
- #63 は役目を終えたためクローズ予定です

## 変更内容

- `CLAUDE.md` の `Updating Workflow Files in Student Repositories` セクション:
  - `Correct Procedure` → `Correct Procedure (Automated)` に変更し、`propagate-workflow`（単一/全件/dry-run）の使用例を追記
  - 実行前提（チェックアウトのルート起点、escript ビルド手順）を明記
  - 既存の手動手順を `Manual Procedure (if needed)` として再構成
- コマンド表記を実体に合わせて統一:
  - ルート起点で `./registry_manager/registry-manager ...`
  - ディレクトリは `registry_manager/`、実行バイナリは `registry-manager`
- `docs/PR-REVIEW-GUIDELINES.md` の関連箇所も同じ表記へ更新:
  - `./registry-manager` 参照を `./registry_manager/registry-manager` に修正
  - `registry_manager_v3/` リンクを `registry_manager/` に修正