### PR TITLE
Add read-only ecosystem update dashboard

### DIFF
--- a/.github/scripts/build-dashboard.sh
+++ b/.github/scripts/build-dashboard.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# build-dashboard.sh — Render the Ecosystem Update Dashboard issue body.
+#
+# Collects the current update state across the LaTeX ecosystem and prints a
+# Markdown body to stdout. Read-only: it queries GitHub but never triggers any
+# workflow. The update-dashboard.yml workflow captures this output and upserts
+# it into a single pinned issue.
+#
+# Requires: gh (authenticated via GH_TOKEN), jq, base64.
+set -euo pipefail
+
+OWNER="${DASHBOARD_OWNER:-smkwlab}"
+NOW="$(date -u +"%Y-%m-%d %H:%M UTC")"
+
+# --- collect -----------------------------------------------------------------
+
+# Latest texlive-ja-textlint release tag (YYYY[letter], version-sorted).
+LATEST="$(gh api "repos/${OWNER}/texlive-ja-textlint/tags" --paginate --jq '.[].name' \
+  | grep -E '^[0-9]{4}[a-z]*$' | sort -V | tail -1)"
+
+# Image tag pinned in latex-environment's devcontainer.json on a given ref.
+pin_of() {
+  gh api "repos/${OWNER}/latex-environment/contents/.devcontainer/devcontainer.json?ref=$1" \
+    --jq '.content' | base64 -d | sed -e 's|//.*||g' | jq -r '.image' \
+    | sed -n 's/.*texlive-ja-textlint://p'
+}
+MAIN_PIN="$(pin_of main || echo '?')"
+REL_PIN="$(pin_of release || echo '?')"
+
+# ⚠️ / ✅ depending on whether a pin already matches the latest release.
+state() { [ "$1" = "$LATEST" ] && echo "✅ 最新" || echo "⚠️ 更新可能"; }
+
+# Open update PRs in latex-environment (title mentions texlive).
+PRS="$(gh api "repos/${OWNER}/latex-environment/pulls" \
+  --jq '.[] | select(.title|test("texlive";"i")) | "- \(.html_url) — \(.title)"' || true)"
+[ -z "$PRS" ] && PRS="- (なし)"
+
+# --- render ------------------------------------------------------------------
+
+cat <<EOF
+# 📊 Ecosystem Update Dashboard
+
+_最終更新: ${NOW}・このIssueはワークフローが自動生成します（手動編集は次回更新で上書きされます）_
+
+このダッシュボードは読み取り専用です。状態を一覧し、実行コマンドを案内します。
+
+## 🐳 Docker イメージ (texlive-ja-textlint)
+
+最新リリース: \`${LATEST}\`
+
+| 参照箇所 | 現在のpin | 最新 | 状態 |
+|---|---|---|---|
+| latex-environment \`main\` | \`${MAIN_PIN}\` | \`${LATEST}\` | $(state "$MAIN_PIN") |
+| latex-environment \`release\`（aldc配布元） | \`${REL_PIN}\` | \`${LATEST}\` | $(state "$REL_PIN") |
+
+## 🔀 進行中の更新 PR
+
+${PRS}
+
+## ▶️ 手動アクション（コピペで実行）
+
+\`\`\`bash
+# 1) texlive 更新PRを生成（latex-environment）
+gh workflow run check-texlive-updates.yml --repo ${OWNER}/latex-environment
+
+# 2) マージ後: release ブランチを更新
+gh workflow run update-release-branch.yml --repo ${OWNER}/latex-environment
+\`\`\`
+
+## 🎓 学生リポジトリへの伝播（thesis-student-registry チェックアウトのルートから）
+
+\`\`\`bash
+(cd registry_manager && mix escript.build)   # 初回のみ
+./registry_manager/registry-manager propagate-workflow --all --type thesis --dry-run
+./registry_manager/registry-manager propagate-workflow --all --type thesis
+\`\`\`
+EOF

--- a/.github/scripts/build-dashboard.sh
+++ b/.github/scripts/build-dashboard.sh
@@ -16,8 +16,11 @@ NOW="$(date -u +"%Y-%m-%d %H:%M UTC")"
 # --- collect -----------------------------------------------------------------
 
 # Latest texlive-ja-textlint release tag (YYYY[letter], version-sorted).
-LATEST="$(gh api "repos/${OWNER}/texlive-ja-textlint/tags" --paginate --jq '.[].name' \
-  | grep -E '^[0-9]{4}[a-z]*$' | sort -V | tail -1)"
+# Degrade to "?" instead of aborting if the API is flaky or returns no tags,
+# so a transient hiccup never leaves the dashboard stale.
+LATEST="$(gh api "repos/${OWNER}/texlive-ja-textlint/tags" --paginate --jq '.[].name' 2>/dev/null \
+  | grep -E '^[0-9]{4}[a-z]*$' | sort -V | tail -1 || true)"
+[ -z "$LATEST" ] && LATEST="?"
 
 # Image tag pinned in latex-environment's devcontainer.json on a given ref.
 pin_of() {
@@ -28,12 +31,22 @@ pin_of() {
 MAIN_PIN="$(pin_of main || echo '?')"
 REL_PIN="$(pin_of release || echo '?')"
 
-# ⚠️ / ✅ depending on whether a pin already matches the latest release.
-state() { [ "$1" = "$LATEST" ] && echo "✅ 最新" || echo "⚠️ 更新可能"; }
+# Status cell: ❓ when either side is unknown, ✅ when already current, ⚠️ when
+# the pin lags the latest release.
+state() {
+  if [ "$LATEST" = "?" ] || [ "$1" = "?" ]; then
+    echo "❓ 判定不可"
+  elif [ "$1" = "$LATEST" ]; then
+    echo "✅ 最新"
+  else
+    echo "⚠️ 更新可能"
+  fi
+}
 
 # Open update PRs in latex-environment (title mentions texlive).
-PRS="$(gh api "repos/${OWNER}/latex-environment/pulls" \
-  --jq '.[] | select(.title|test("texlive";"i")) | "- \(.html_url) — \(.title)"' || true)"
+# --paginate so the list stays complete beyond the first 30 results.
+PRS="$(gh api --paginate "repos/${OWNER}/latex-environment/pulls?state=open&per_page=100" \
+  --jq '.[] | select(.title|test("texlive";"i")) | "- \(.html_url) — \(.title)"' 2>/dev/null || true)"
 [ -z "$PRS" ] && PRS="- (なし)"
 
 # --- render ------------------------------------------------------------------

--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -1,0 +1,65 @@
+---
+name: Ecosystem Update Dashboard
+
+# Maintains a single read-only "dashboard" issue that summarises pending
+# ecosystem updates (texlive-ja-textlint image, latex-environment pins, open
+# update PRs) and lists the commands to act on them. It never triggers other
+# workflows; acting on an update stays a deliberate manual step.
+
+on:
+  schedule:
+    # Daily at 23:30 UTC (08:30 JST), just after check-texlive-updates runs.
+    - cron: '30 23 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: update-dashboard
+  cancel-in-progress: true
+
+jobs:
+  dashboard:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DASHBOARD_LABEL: update-dashboard
+      DASHBOARD_TITLE: "📊 Ecosystem Update Dashboard"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build dashboard body
+        run: bash .github/scripts/build-dashboard.sh > body.md
+
+      - name: Upsert dashboard issue
+        run: |
+          # Ensure the tracking label exists (idempotent).
+          gh label create "$DASHBOARD_LABEL" \
+            --color FBCA04 \
+            --description "Ecosystem update dashboard (auto-maintained)" \
+            --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          # Find the existing open dashboard issue, if any.
+          ISSUE=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "$DASHBOARD_LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$ISSUE" ]; then
+            echo "Updating dashboard issue #$ISSUE"
+            gh issue edit "$ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file body.md
+          else
+            echo "Creating dashboard issue"
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$DASHBOARD_TITLE" \
+              --label "$DASHBOARD_LABEL" \
+              --body-file body.md
+          fi

--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -44,11 +44,13 @@ jobs:
 
           # All open issues carrying the label, oldest first. The lowest number
           # is the canonical dashboard; any others are duplicates to be closed,
-          # so the dashboard self-heals to a single issue.
+          # so the dashboard self-heals to a single issue. --limit overrides the
+          # default cap of 30 so even a large duplicate pile-up fully heals.
           ISSUES=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --label "$DASHBOARD_LABEL" \
             --state open \
+            --limit 1000 \
             --json number \
             --jq '.[].number' | sort -n)
 

--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -42,24 +42,39 @@ jobs:
             --description "Ecosystem update dashboard (auto-maintained)" \
             --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
-          # Find the existing open dashboard issue, if any.
-          ISSUE=$(gh issue list \
+          # All open issues carrying the label, oldest first. The lowest number
+          # is the canonical dashboard; any others are duplicates to be closed,
+          # so the dashboard self-heals to a single issue.
+          ISSUES=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --label "$DASHBOARD_LABEL" \
             --state open \
             --json number \
-            --jq '.[0].number // empty')
+            --jq '.[].number' | sort -n)
 
-          if [ -n "$ISSUE" ]; then
-            echo "Updating dashboard issue #$ISSUE"
-            gh issue edit "$ISSUE" \
-              --repo "$GITHUB_REPOSITORY" \
-              --body-file body.md
+          CANON=$(printf '%s\n' "$ISSUES" | head -n 1)
+
+          if [ -n "$CANON" ]; then
+            echo "Updating dashboard issue #$CANON"
+            gh issue edit "$CANON" --repo "$GITHUB_REPOSITORY" --body-file body.md
+
+            # Close any extra labelled issues as duplicates.
+            printf '%s\n' "$ISSUES" | tail -n +2 | while read -r dup; do
+              [ -n "$dup" ] || continue
+              echo "Closing duplicate dashboard issue #$dup"
+              gh issue close "$dup" --repo "$GITHUB_REPOSITORY" \
+                --comment "Duplicate of #$CANON — the dashboard is auto-maintained as a single issue."
+            done
           else
             echo "Creating dashboard issue"
-            gh issue create \
+            URL=$(gh issue create \
               --repo "$GITHUB_REPOSITORY" \
               --title "$DASHBOARD_TITLE" \
               --label "$DASHBOARD_LABEL" \
-              --body-file body.md
+              --body-file body.md)
+            CANON="${URL##*/}"
           fi
+
+          # Pin for discoverability (best-effort: ignore if already pinned or
+          # the repo's 3-pin limit is reached).
+          gh issue pin "$CANON" --repo "$GITHUB_REPOSITORY" 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@
 # Exception: Include ecosystem_manager Elixir project
 !ecosystem_manager/
 
+# Exception: Include .github (workflows, scripts, settings) for this repo
+# Re-include nested paths too: the leading */ rule also matches subdirectories
+# such as .github/workflows, so a single !.github/ is not enough.
+!.github/
+!.github/**
+
 # macOS system files
 .DS_Store
 .DS_Store?


### PR DESCRIPTION
## 概要

Renovate の Dependency Dashboard に着想を得た、**読み取り専用のエコシステム更新ダッシュボード**を追加します。エコシステムにまたがる更新状況を1つの自動メンテナンス Issue に集約し、対応コマンドを案内します。**自身は何もトリガーしません**（更新の実行は意図的な手動ステップのまま）。

## 追加ファイル

- **`.github/scripts/build-dashboard.sh`** — Issue 本文を生成。
  - texlive-ja-textlint の最新リリース vs latex-environment の \`main\`/\`release\` の pin
  - texlive 更新の open PR 一覧
  - 手動フォローアップ手順のコピペコマンド（更新PR生成 / release ブランチ更新 / 学生リポジトリ伝播）
- **`.github/workflows/update-dashboard.yml`** — 日次（23:30 UTC）＋ \`workflow_dispatch\` で実行し、\`update-dashboard\` ラベルで識別する Issue を upsert。
- **`.gitignore`** — 本リポジトリは全サブディレクトリを除外する設計のため、\`.github/\` を追跡対象に再包含。サブリポジトリ（latex-environment 等）が誤って追跡されないことは確認済み。

## 設計上のポイント

- **読み取り専用**: 状態の可視化と案内に徹し、ワークフロー発火はしない。将来チェックボックス駆動の発火に拡張可能な土台。
- **冪等な upsert**: ラベルで既存 Issue を検索し、あれば本文更新・無ければ新規作成。

## 検証

- ✅ \`build-dashboard.sh\` をローカル実行し、実データで正しくレンダリング（main/release ともに \`2025i\` → \`2026a\` 更新可能を検出）
- ✅ \`actionlint\` / \`yamllint\`(max:120) / \`shellcheck\` すべて PASS
- ✅ \`.gitignore\` 変更後もサブリポジトリが非追跡のままであることを確認

## マージ後

新規ワークフローは default ブランチに載らないと \`workflow_dispatch\` で起動できないため、マージ後に以下で初回生成します:

\`\`\`bash
gh workflow run update-dashboard.yml --repo smkwlab/latex-ecosystem
\`\`\`

## 今後の拡張余地（別PR）

チェックボックス駆動の発火（Renovate 型）— \`on: issues: types: [edited]\` + \`changes.body.from\` 差分 + allowlist ガード + クロスリポジトリ発火用 PAT。