### PR TITLE
Update version compatibility table to texlive-ja-textlint 2026a

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -51,14 +51,14 @@ Supporting Infrastructure:
 
 | Component | Current Version | Compatible With | Update Frequency |
 |-----------|----------------|-----------------|------------------|
-| texlive-ja-textlint | 2025d | TeXLive 2025 | Annual (TeXLive release) |
-| latex-environment | v0.5.0 | texlive-ja-textlint:2025d | Per texlive update |
+| texlive-ja-textlint | 2026a | TeXLive 2026 | Annual (TeXLive release) |
+| latex-environment | release branch | texlive-ja-textlint:2026a | Auto (on merge to main) |
 | sotsuron-template | Latest | Auto-updated via aldc | No manual updates needed |
 | latex-template | Latest | Auto-updated via aldc | No manual updates needed |
 | wr-template | Latest | Auto-updated via aldc | No manual updates needed |
 | sotsuron-report-template | Latest | Auto-updated via aldc | No manual updates needed |
 | poster-template | Latest | Auto-updated via aldc | No manual updates needed |
-| latex-release-action | v2.2.0 | All templates | Per feature |
+| latex-release-action | v3.3.0 | All templates | Per feature |
 | aldc | Latest | latex-environment:release | No updates needed |
 
 ## Automated Update Chain
@@ -70,7 +70,8 @@ Supporting Infrastructure:
    ↓  
 3. Manual PR review and merge to main branch
    ↓
-4. Manual latex-environment release branch update
+4. latex-environment release branch updated automatically
+   (update-release-branch workflow on merge to main)
    ↓
 5. aldc automatically uses updated release branch
    ↓


### PR DESCRIPTION
## Summary

Refresh the stale Version Compatibility table and update chain in `ECOSYSTEM.md` following the merge of smkwlab/latex-environment#148 (texlive-ja-textlint 2026a).

## Changes

| Entry | Before | After |
|-------|--------|-------|
| texlive-ja-textlint | 2025d (TeXLive 2025) | 2026a (TeXLive 2026) |
| latex-environment | v0.5.0 / `texlive-ja-textlint:2025d` | release branch / `texlive-ja-textlint:2026a` |
| latex-release-action | v2.2.0 | v3.3.0 |

- latex-environment no longer uses version tags (deprecated since #115 there); the table now points to the auto-updated `release` branch instead.
- Step 4 of the "Automated Update Chain" said the release branch update was manual; it is automated by the `update-release-branch` workflow, so the text now reflects that.

## Verification

- `release` branch of latex-environment is at `3f52e70` ("Update release branch for texlive-ja-textlint 2026a") — updated automatically after #148 merged.
- `ghcr.io/smkwlab/texlive-ja-textlint:2026a` image manifest exists (HTTP 200).
- latex-release-action latest tag is v3.3.0.
- aldc pins no version (fetches `release` branch zip), and templates carry no `.devcontainer`, so no other repositories need changes for the 2026a rollout.