### PR TITLE
Update docs and setup.sh to the Elixir ecosystem-manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,24 +27,30 @@ Each step builds upon previous knowledge while introducing new collaborative wri
 ## Quick Start
 
 ### Ecosystem Management Commands
+
+The manager is an Elixir escript. Build it once with
+`(cd ecosystem_manager && mix escript.build)`, then:
+
 ```bash
-# Show status of all repositories
-./ecosystem-manager.sh status
+# Show status of all repositories (default command)
+./ecosystem_manager/ecosystem-manager status
 
-# Check dependency relationships
-./ecosystem-manager.sh deps
+# Detailed status: branch, uncommitted changes, last commit, PRs, issues
+./ecosystem_manager/ecosystem-manager status --long
 
-# Sync all repositories
-./ecosystem-manager.sh sync
+# Fast status without GitHub API calls
+./ecosystem_manager/ecosystem-manager status --fast
 
-# Check for uncommitted changes
-./ecosystem-manager.sh check
+# Show only repositories with urgent issues / open PRs / PRs needing review
+./ecosystem_manager/ecosystem-manager status --urgent-issues
+./ecosystem_manager/ecosystem-manager status --with-prs
+./ecosystem_manager/ecosystem-manager status --needs-review
 
-# Show version information
-./ecosystem-manager.sh versions
+# Show repository configuration and sources
+./ecosystem_manager/ecosystem-manager repos
 
-# Check CLAUDE.md tracking status
-./ecosystem-manager.sh claude-status
+# Show current configuration
+./ecosystem_manager/ecosystem-manager config
 ```
 
 ### Working with Components
@@ -86,7 +92,7 @@ This directory contains multiple **independent Git repositories**:
 ## Important Conventions
 
 ### This Management Repository
-- **Tracks**: ECOSYSTEM.md, ecosystem-manager.sh, README.md, CLAUDE.md, .claude/, docs/
+- **Tracks**: ECOSYSTEM.md, ecosystem_manager/, README.md, CLAUDE.md, .claude/, docs/
 - **Excludes**: All subdirectories except docs/ (they are independent repositories)
 - **Purpose**: Cross-repository coordination and documentation
 
@@ -121,7 +127,7 @@ thesis-monitor status --verbose
 ### For Ecosystem-level Changes
 1. Work in this management repository
 2. Update ECOSYSTEM.md for architectural changes
-3. Use ecosystem-manager.sh for coordination
+3. Use ecosystem_manager/ecosystem-manager for coordination
 
 ### For Component-specific Changes
 1. Navigate to the specific repository directory

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This directory contains multiple independent Git repositories that work together
 ```
 latex-ecosystem/
 ├── ECOSYSTEM.md              # This management repository
-├── ecosystem-manager.sh      # Cross-repository management script
+├── ecosystem_manager/        # Cross-repository management tool (Elixir escript)
+├── setup.sh                  # Automated setup script
 ├── README.md                 # This file
 ├── docs/                     # Detailed documentation
 │
@@ -32,7 +33,7 @@ latex-ecosystem/
 
 - **Git**: Version control system
 - **GitHub CLI (gh)**: Required for PR/Issue tracking features
-- **jq**: JSON processor for parsing API responses
+- **Elixir/Mix** (with Erlang/OTP): Required to build and run the ecosystem-manager escript
 - **Bash**: Shell interpreter (version 4.0+)
 
 ### GitHub CLI Setup
@@ -76,18 +77,20 @@ cd latex-ecosystem-dev
 
 ### Daily Ecosystem Management
 
+> **First time?** Build the escript once: `(cd ecosystem_manager && mix escript.build)`
+
 ```bash
 # Check status of all repositories
-./ecosystem-manager.sh status
+./ecosystem_manager/ecosystem-manager status
 
-# Show dependency relationships
-./ecosystem-manager.sh deps
+# Detailed status (branch, uncommitted changes, last commit, PRs, issues)
+./ecosystem_manager/ecosystem-manager status --long
 
-# Check CLAUDE.md tracking across repos
-./ecosystem-manager.sh claude-status
+# Fast status without GitHub API calls
+./ecosystem_manager/ecosystem-manager status --fast
 
-# Sync all repositories
-./ecosystem-manager.sh sync
+# Show repository configuration and sources
+./ecosystem_manager/ecosystem-manager repos
 ```
 
 ### For Students
@@ -125,7 +128,7 @@ Review workflow documentation is available in `thesis-management-tools/docs/`.
 This management repository contains:
 - **ECOSYSTEM.md**: Comprehensive ecosystem architecture documentation
 - **docs/**: Detailed documentation directory with specialized guides
-- **ecosystem-manager.sh**: Cross-repository management script
+- **ecosystem_manager/**: Cross-repository management tool (Elixir escript)
 - **setup.sh**: Automated setup script for cloning all repositories
 - **README.md**: This overview file
 
@@ -144,7 +147,7 @@ Each subdirectory is a separate Git repository with its own:
 ### For Ecosystem-wide Changes
 
 1. Update documentation in this repository
-2. Use ecosystem-manager.sh to coordinate changes
+2. Use ecosystem_manager/ecosystem-manager to coordinate changes
 3. Create issues in relevant individual repositories
 4. Test changes across the ecosystem
 

--- a/docs/CLAUDE-ARCHITECTURE.md
+++ b/docs/CLAUDE-ARCHITECTURE.md
@@ -26,7 +26,7 @@ This document covers the architecture, dependencies, and coordination patterns f
 latex-ecosystem/                 # This management repository
 ├── .git/                       # Git for management files only
 ├── ECOSYSTEM.md                # Tracked - ecosystem overview
-├── ecosystem-manager.sh        # Tracked - coordination scripts
+├── ecosystem_manager/          # Tracked - coordination tool (Elixir escript)
 ├── CLAUDE.md                   # Tracked - this file
 ├── .claude/                    # Tracked - claude configuration
 ├── docs/                       # Tracked - ecosystem documentation
@@ -99,5 +99,5 @@ thesis-management-tools (student workflows)
 
 ### Compatibility Management
 - **Version matrices**: Documented in ECOSYSTEM.md
-- **Testing coordination**: Use ecosystem-manager.sh for validation
+- **Testing coordination**: Use ecosystem_manager/ecosystem-manager for validation
 - **Breaking change communication**: Cross-repository issue coordination

--- a/docs/CLAUDE-SETUP.md
+++ b/docs/CLAUDE-SETUP.md
@@ -7,7 +7,7 @@ This comprehensive guide covers setup, dependency management, and release proces
 ### Required Tools
 - **Git**: Version control system
 - **GitHub CLI (`gh`)**: Required for PR/Issue tracking, recommended for easier cloning
-- **jq**: JSON processor (required for ecosystem-manager.sh)
+- **Elixir/Mix** (with Erlang/OTP): Required to build and run the `ecosystem-manager` escript
 - **Bash**: Shell interpreter (version 4.0+)
 
 ### Optional Tools
@@ -81,11 +81,14 @@ git clone https://github.com/smkwlab/latex-ecosystem.git .
 ### 3. Verify Installation
 
 ```bash
-# Check ecosystem status
-./ecosystem-manager.sh status
+# Build the manager once (Elixir escript)
+(cd ecosystem_manager && mix escript.build)
 
-# Verify all repositories are present
-./ecosystem-manager.sh deps
+# Check ecosystem status
+./ecosystem_manager/ecosystem-manager status
+
+# Show repository configuration and sources
+./ecosystem_manager/ecosystem-manager repos
 ```
 
 ## Dependency Management
@@ -247,8 +250,8 @@ gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
 #### 3. Testing Phase
 
 ```bash
-# Ecosystem-wide compatibility testing
-./ecosystem-manager.sh check
+# Ecosystem-wide status check (branches, uncommitted changes, PRs)
+./ecosystem_manager/ecosystem-manager status --long
 
 # Test critical workflows
 cd thesis-management-tools/
@@ -351,11 +354,10 @@ Investigation ongoing.
 
 ```bash
 # Weekly maintenance
-./ecosystem-manager.sh status
-./ecosystem-manager.sh claude-status
+./ecosystem_manager/ecosystem-manager status --long
 
 # Monthly maintenance
-./ecosystem-manager.sh sync
+# Pull the latest changes in each repository as needed (git pull)
 # Review and update documentation
 # Check for upstream updates (TeXLive, Node.js, etc.)
 
@@ -374,8 +376,8 @@ Investigation ongoing.
 # - Student repository creation issues
 # - Compilation failures in templates
 
-# Use ecosystem-manager.sh for automated checks
-./ecosystem-manager.sh check --automated
+# Use ecosystem-manager for status checks (e.g. in cron / CI)
+./ecosystem_manager/ecosystem-manager status --fast
 ```
 
 ## Development Best Practices

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -5,36 +5,42 @@ This document provides workflow examples specifically for ecosystem management t
 ## Ecosystem Management Commands
 
 ### Comprehensive Command Reference
+
+The manager is an Elixir escript. Build it once with
+`(cd ecosystem_manager && mix escript.build)`, then:
+
 ```bash
-# Show status of all repositories
-./ecosystem-manager.sh status
+# Show status of all repositories (default command)
+./ecosystem_manager/ecosystem-manager status
 
-# Check dependency relationships
-./ecosystem-manager.sh deps
+# Detailed status: branch, uncommitted changes, last commit, PRs, issues
+./ecosystem_manager/ecosystem-manager status --long
 
-# Sync all repositories
-./ecosystem-manager.sh sync
+# Fast status without GitHub API calls
+./ecosystem_manager/ecosystem-manager status --fast
 
-# Check for uncommitted changes
-./ecosystem-manager.sh check
+# Filter: urgent issues / open PRs / PRs needing review
+./ecosystem_manager/ecosystem-manager status --urgent-issues
+./ecosystem_manager/ecosystem-manager status --with-prs
+./ecosystem_manager/ecosystem-manager status --needs-review
 
-# Show version information
-./ecosystem-manager.sh versions
+# Show repository configuration and sources
+./ecosystem_manager/ecosystem-manager repos
 
-# Check CLAUDE.md tracking status
-./ecosystem-manager.sh claude-status
+# Show current configuration
+./ecosystem_manager/ecosystem-manager config
 ```
 
 ### Status Monitoring Examples
 ```bash
-# Quick ecosystem health check
-./ecosystem-manager.sh status | grep -E "(AHEAD|BEHIND|DIRTY)"
+# Quick ecosystem health check (rows with branch/commit/change info)
+./ecosystem_manager/ecosystem-manager status --long
 
-# Version compatibility check
-./ecosystem-manager.sh versions | grep -E "texlive-ja-textlint|latex-environment"
+# Show only repositories that need attention
+./ecosystem_manager/ecosystem-manager status --urgent-issues
+./ecosystem_manager/ecosystem-manager status --needs-review
 
-# Documentation consistency check
-./ecosystem-manager.sh claude-status
+# Version compatibility is tracked in ECOSYSTEM.md (compatibility matrix)
 ```
 
 ## Repository Navigation and Operations
@@ -93,8 +99,7 @@ git push origin main
 #### Cross-repository Coordination
 ```bash
 # Check current state
-./ecosystem-manager.sh status
-./ecosystem-manager.sh versions
+./ecosystem_manager/ecosystem-manager status
 
 # Coordinate updates
 vim ECOSYSTEM.md  # Document planned changes
@@ -167,8 +172,7 @@ done
 ### Issue Tracking and Coordination
 ```bash
 # Track progress across repositories
-./ecosystem-manager.sh status
-./ecosystem-manager.sh versions
+./ecosystem_manager/ecosystem-manager status --with-prs
 
 # Check issue status across ecosystem
 for repo in */; do
@@ -185,8 +189,8 @@ done
 
 ### Ecosystem-wide Testing
 ```bash
-# Validate all repositories
-./ecosystem-manager.sh check
+# Validate all repositories (branches, uncommitted changes)
+./ecosystem_manager/ecosystem-manager status --long
 
 # Test compilation across templates
 templates=("sotsuron-template" "wr-template" "latex-template")
@@ -202,8 +206,8 @@ done
 
 ### Compatibility Validation
 ```bash
-# Check version compatibility
-./ecosystem-manager.sh versions > versions.txt
+# Version compatibility is documented in ECOSYSTEM.md (compatibility matrix);
+# review it when coordinating updates.
 
 # Validate dependency chain
 echo "Checking texlive-ja-textlint → latex-environment compatibility..."
@@ -220,7 +224,7 @@ grep -r "latex-environment" .devcontainer/
 ### Cross-Repository Documentation Updates
 ```bash
 # When CLAUDE.md structure changes across ecosystem
-./ecosystem-manager.sh claude-status  # Check current state
+./ecosystem_manager/ecosystem-manager status  # Check current state
 
 # Plan documentation updates
 for repo in texlive-ja-textlint latex-environment sotsuron-template; do
@@ -231,7 +235,7 @@ for repo in texlive-ja-textlint latex-environment sotsuron-template; do
 done
 
 # Track progress
-./ecosystem-manager.sh claude-status  # Verify updates
+./ecosystem_manager/ecosystem-manager status  # Verify updates
 ```
 
 ### Issue Coordination

--- a/setup.sh
+++ b/setup.sh
@@ -70,6 +70,13 @@ check_prerequisites() {
     else
         print_warning "Docker is not installed (optional for testing)"
     fi
+
+    # Check Elixir/Mix (required to build the ecosystem-manager escript)
+    if command -v mix &> /dev/null; then
+        print_status "Elixir/Mix is installed"
+    else
+        print_warning "Elixir/Mix is not installed (required to build ecosystem-manager)"
+    fi
 }
 
 setup_base_directory() {
@@ -115,11 +122,20 @@ setup_ecosystem_management() {
         print_warning "Directory already contains a git repository"
     fi
     
-    # Verify ecosystem-manager.sh exists
-    if [ -f ecosystem-manager.sh ]; then
-        print_status "ecosystem-manager.sh is ready"
+    # Build the ecosystem-manager escript (Elixir)
+    if [ -f ecosystem_manager/mix.exs ]; then
+        if command -v mix &> /dev/null; then
+            echo "Building ecosystem-manager (Elixir escript)..."
+            if ( cd ecosystem_manager && mix deps.get && mix escript.build ); then
+                print_status "ecosystem-manager is ready"
+            else
+                print_warning "Failed to build ecosystem-manager (build it later: cd ecosystem_manager && mix escript.build)"
+            fi
+        else
+            print_warning "Skipping ecosystem-manager build (Elixir/Mix not found). Build later: cd ecosystem_manager && mix escript.build"
+        fi
     else
-        print_error "ecosystem-manager.sh not found"
+        print_error "ecosystem_manager/mix.exs not found"
         exit 1
     fi
 }
@@ -216,15 +232,17 @@ main() {
     
     # Final verification
     echo -e "\nVerifying setup..."
-    if [ -x ecosystem-manager.sh ]; then
-        ./ecosystem-manager.sh status
+    if [ -x ecosystem_manager/ecosystem-manager ]; then
+        ./ecosystem_manager/ecosystem-manager status
         print_status "Setup completed successfully!"
         echo -e "\nNext steps:"
         echo "  cd $BASE_DIR"
-        echo "  ./ecosystem-manager.sh check"
+        echo "  ./ecosystem_manager/ecosystem-manager status --long"
     else
-        print_error "Setup verification failed"
-        exit 1
+        print_warning "Setup completed, but ecosystem-manager is not built yet."
+        echo -e "\nTo build it:"
+        echo "  cd $BASE_DIR/ecosystem_manager && mix escript.build"
+        echo "  ./ecosystem_manager/ecosystem-manager status"
     fi
 }
 


### PR DESCRIPTION
resolve #71

`ecosystem-manager.sh` はコミット 2127480 で削除され Elixir 製 escript（`ecosystem_manager/ecosystem-manager`）に置き換えられていましたが、ドキュメントと `setup.sh` が旧スクリプトと存在しないサブコマンドを参照したままでした。**特に `setup.sh` は旧スクリプトの存在チェックで必ず失敗する状態**でした。

## 主な変更

### setup.sh（壊れていた箇所の修復）
- 旧 `ecosystem-manager.sh` 存在チェックを **escript ビルド**（`mix escript.build`）に変更。escript バイナリはリポジトリにコミットされていないため、クローン後のビルドが必要
- prerequisites に **Elixir/Mix** チェックを追加
- 最終検証と次ステップ案内を `./ecosystem_manager/ecosystem-manager` に変更（未ビルド時はビルド手順を案内し、`set -e` 下でも止まらないよう warning 化）

### 廃止サブコマンドの実 CLI へのマッピング
Elixir 版に存在しないコマンドを実態へ置換:
| 旧 | 新 |
|---|---|
| `deps` | `repos`（監視リポジトリ構成） |
| `check`（未コミット確認） | `status --long`（Changes 列） |
| `versions` | 廃止 → ECOSYSTEM.md 互換表へ誘導 |
| `sync` | 廃止 → 手動 `git pull` |
| `claude-status` | 廃止 → `status` |

実在コマンド: `status`（`--long`/`--fast`/`--urgent-issues`/`--with-prs`/`--needs-review`）, `config`, `repos`, `workspace`, `init-config`, `help`

### ドキュメント
- `README.md` / `CLAUDE.md` / `docs/CLAUDE-WORKFLOWS.md` / `CLAUDE-SETUP.md` / `CLAUDE-ARCHITECTURE.md` のパス・コマンド例・リポジトリツリーを更新
- prerequisites の「jq（ecosystem-manager.sh に必要）」を **Elixir/Mix（Erlang/OTP）** に置換（jq は escript では不要）

## 検証
- ✅ `ecosystem-manager.sh` 残存参照: 0
- ✅ 廃止サブコマンド残存: 0
- ✅ `bash -n setup.sh`: OK
- ✅ 旧 jq 必須記述: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)