### PR TITLE
ci: add org-standard ai-code-review caller

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,0 +1,27 @@
+# Caller template: AI Code Review (one-shot, inline) — calls the ai-review reusable.
+# Distributed by scripts/distribute-workflow.sh as
+# .github/workflows/ai-code-review.yml in each target repository.
+# The ref / model / language tokens below are substituted at distribution time.
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing every push
+
+concurrency:
+  group: ai-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: smkwlab/.github/.github/workflows/ai-review.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+    with:
+      model_code: claude-sonnet-4-6
+      review_mode: CODE
+      language: Japanese

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,7 +1,6 @@
-# Caller template: AI Code Review (one-shot, inline) — calls the ai-review reusable.
-# Distributed by scripts/distribute-workflow.sh as
-# .github/workflows/ai-code-review.yml in each target repository.
-# The ref / model / language tokens below are substituted at distribution time.
+# AI Code Review (one-shot, inline) — calls the smkwlab org-standard
+# ai-review reusable workflow (smkwlab/.github). Maintained manually in this
+# repository; the ref / model / language values below are set directly.
 name: AI Code Review
 
 on:


### PR DESCRIPTION
## 概要

smkwlab 組織標準の **AI Code Review** ワークフローを latex-ecosystem に導入します。`smkwlab/.github` の再利用ワークフロー `ai-review.yml@v1`（Claude / 日本語）を呼び出す caller です。

## 背景

- thesis-management-tools では #443 で同じ移行（org標準 ai-code-review への統一）を実施済み
- latex-ecosystem には未導入で、PR レビューは Copilot に依存していたが、**Copilot のレビュー枠（quota）上限**でレビュー不能になる事象が発生（例: PR #66）
- 本ワークフロー導入により、以降の PR は組織標準の ai-code-review が自動でレビュー

## 変更内容

- `.github/workflows/ai-code-review.yml` を追加（thesis-management-tools と同一構成）
  - トリガ: `pull_request`（opened / reopened / ready_for_review。`synchronize` は除外し push 毎の再レビューを回避）
  - 呼び出し: `smkwlab/.github/.github/workflows/ai-review.yml@v1`
  - 設定: `model_code: claude-sonnet-4-6` / `review_mode: CODE` / `language: Japanese`

## 注意

- 動作には org/repo レベルの `ANTHROPIC_API_KEY`（および `GEMINI_API_KEY`）secret が必要です。組織標準のため設定済みの想定ですが、未設定の場合は別途登録が必要です。

Relates to smkwlab/thesis-management-tools#443