### PR TITLE
docs: mark ai-reviewer as legacy and clarify ai-academic-paper-reviewer role

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,8 +20,8 @@ This document describes the architecture and management strategy for the thesis-
 ### Management & Automation
 - **thesis-management-tools**: Administrative tools and documentation for thesis supervision
 - **thesis-student-registry**: Student repository registry and monitoring tools (registry-manager / thesis-monitor escripts)
-- **ai-academic-paper-reviewer**: GitHub Action for automated academic paper review using Gemini AI
-- **ai-reviewer**: Automated PR code review GitHub Action (fork maintained for upstream bug fixes)
+- **ai-academic-paper-reviewer**: GitHub Action for automated review via the org-standard AI review workflow; supports both `ACADEMIC` (paper) and `CODE` review modes, so it is the single AI reviewer for the ecosystem
+- **ai-reviewer** (legacy): standalone code-review Action hosted at `toshi0806/ai-reviewer` (a fork of `Nasubikun/ai-reviewer`). Superseded by `ai-academic-paper-reviewer` (`CODE` mode) and no longer used by the migrated workflows; kept for reference only
 - **aldc**: Command-line tool for adding LaTeX devcontainer to repositories
 
 > **Out of ecosystem scope**: Other repositories that may appear alongside these in a local
@@ -48,8 +48,7 @@ latex-environment (DevContainer Template)
 
 Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)
-├── ai-academic-paper-reviewer → (Used by thesis repos)
-├── ai-reviewer → (Used for PR code review)
+├── ai-academic-paper-reviewer → (AI review for thesis repos & code review, ACADEMIC/CODE modes)
 ├── aldc → latex-environment (release branch)
 ├── thesis-management-tools → (Management workflows)
 └── thesis-student-registry → (Student repository registry & monitoring)


### PR DESCRIPTION
#73 のフォローアップ（調査で判明した事実に基づく ECOSYSTEM.md の正確化）。

## 背景

#76 で ECOSYSTEM.md に追加した `ai-reviewer` エントリが不正確だったため訂正します。調査の結果:
- `smkwlab/ai-reviewer` は**存在しない**（404）。スタンドアロンのコードレビューアの実体は **`toshi0806/ai-reviewer`**（`Nasubikun/ai-reviewer` の fork）
- エコシステムの AI レビューは org 標準の `ai-review.yml` に移行済みで、内部は **`smkwlab/ai-academic-paper-reviewer`**（`REVIEW_MODE` で ACADEMIC/CODE 両対応）を使用
- `toshi0806/ai-reviewer` は機能的に ai-academic-paper-reviewer に包含されたレガシー

## 変更
- `ai-academic-paper-reviewer` のエントリを「ACADEMIC/CODE 両モード対応の唯一の AI レビューア」と明記
- `ai-reviewer` のエントリを**レガシー**と明記し、正しい所有者（`toshi0806/ai-reviewer`、`Nasubikun/ai-reviewer` の fork）・置換関係を記載
- Dependency Matrix から実態に合わない `ai-reviewer → (Used for PR code review)` 行を削除

## 関連
- #73（クローズ済み、not planned）
- 併せて未追跡の残骸 `thesis-student-registry/.github/workflows/ai-reviewer.yml`（`toshi0806/ai-reviewer@v1` 参照）をローカルで削除済み
- `toshi0806/ai-reviewer` 自体は当面残置（撤去は別途判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)