### PR TITLE
Align repository lists and fix ecosystem_manager gitignore exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,12 @@
 !docs/
 
 # Exception: Include ecosystem_manager Elixir project
+# Re-include nested paths too (same pitfall as .github below): the leading
+# */ rule also matches subdirectories such as ecosystem_manager/lib, so a
+# single !ecosystem_manager/ is not enough. Build artifacts stay ignored
+# via ecosystem_manager/.gitignore.
 !ecosystem_manager/
+!ecosystem_manager/**
 
 # Exception: Include .github (workflows, scripts, settings) for this repo
 # Re-include nested paths too: the leading */ rule also matches subdirectories

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ gh auth status
 
 **Note**: Without GitHub CLI authentication, the ecosystem manager will still work but with limited functionality (no PR/Issue counts).
 
+**Note**: Some ecosystem repositories (e.g. `thesis-student-registry`) are private. `setup.sh` can clone them only with an authenticated GitHub CLI (`gh auth login`) or an SSH key registered on GitHub; the anonymous HTTPS fallback works for public repositories only.
+
 ## Quick Start
 
 ### Initial Setup

--- a/ecosystem_manager/config/config.example.exs
+++ b/ecosystem_manager/config/config.example.exs
@@ -1,0 +1,70 @@
+import Config
+
+# EcosystemManager Configuration Example
+# Copy this file to config.exs and modify as needed
+
+# Logger configuration
+config :logger, level: :info
+
+config :logger, :console,
+  level: :info,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+# EcosystemManager configuration
+config :ecosystem_manager,
+  # Parallel processing settings
+  # Number of concurrent repository processing tasks
+  default_concurrency: 8,
+
+  # Timeout settings (milliseconds)
+  # GitHub API request timeout
+  github_timeout: 15_000,
+  # Git command timeout
+  git_timeout: 5_000,
+
+  # Output formatting
+  # Options: :compact, :long
+  default_format: :compact,
+
+  # Cache settings (for future implementation)
+  # Enable result caching
+  enable_cache: false,
+  # Cache time-to-live (5 minutes)
+  cache_ttl: 300_000,
+
+  # Performance monitoring
+  # Enable execution timing logs
+  enable_timing: false,
+
+  # GitHub API settings
+  github_api_base_url: "https://api.github.com",
+  # Include GitHub data by default
+  default_include_github: true
+
+# Environment-specific configurations
+case config_env() do
+  :dev ->
+    config :ecosystem_manager,
+      # Enable timing in development
+      enable_timing: true,
+      # Lower concurrency for development
+      default_concurrency: 4
+
+  :test ->
+    config :ecosystem_manager,
+      # Shorter timeout for tests
+      github_timeout: 5_000,
+      git_timeout: 2_000,
+      default_concurrency: 2,
+      enable_cache: false
+
+  :prod ->
+    config :ecosystem_manager,
+      # Higher concurrency for production
+      default_concurrency: 12,
+      # Enable caching in production
+      enable_cache: true,
+      # 10 minute cache in production
+      cache_ttl: 600_000
+end

--- a/ecosystem_manager/config/test.exs
+++ b/ecosystem_manager/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+# Test environment configuration
+config :ecosystem_manager,
+  env: :test,
+  # Disable GitHub API calls in tests by default
+  default_include_github: false

--- a/ecosystem_manager/lib/ecosystem_manager/application.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/application.ex
@@ -9,7 +9,9 @@ defmodule EcosystemManager.Application do
 
   @impl true
   def start(_type, _args) do
-    # Load user configuration
+    # Load user configuration. A broken config file is deliberately
+    # non-fatal: the CLI stays usable with built-in defaults, and the
+    # warning tells the user what to fix.
     case EcosystemManager.UserConfig.load() do
       :ok ->
         :ok

--- a/ecosystem_manager/lib/ecosystem_manager/application.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/application.ex
@@ -1,0 +1,25 @@
+defmodule EcosystemManager.Application do
+  @moduledoc """
+  Application module for EcosystemManager.
+
+  Loads user configuration on startup.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    # Load user configuration
+    case EcosystemManager.UserConfig.load() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        IO.puts("Warning: Failed to load user configuration: #{reason}")
+    end
+
+    # No supervision tree needed for a CLI tool
+    opts = [strategy: :one_for_one, name: EcosystemManager.Supervisor]
+    Supervisor.start_link([], opts)
+  end
+end

--- a/ecosystem_manager/lib/ecosystem_manager/config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/config.ex
@@ -1,0 +1,105 @@
+defmodule EcosystemManager.Config do
+  @moduledoc """
+  Configuration management for EcosystemManager.
+
+  Provides centralized access to application configuration with fallback defaults.
+  """
+
+  @doc """
+  Get default concurrency for parallel processing.
+  """
+  def default_concurrency do
+    Application.get_env(:ecosystem_manager, :default_concurrency, 8)
+  end
+
+  @doc """
+  Get GitHub API timeout in milliseconds.
+  """
+  def github_timeout do
+    Application.get_env(:ecosystem_manager, :github_timeout, 15_000)
+  end
+
+  @doc """
+  Get Git command timeout in milliseconds.
+  """
+  def git_timeout do
+    Application.get_env(:ecosystem_manager, :git_timeout, 5_000)
+  end
+
+  @doc """
+  Get default output format.
+  """
+  def default_format do
+    Application.get_env(:ecosystem_manager, :default_format, :compact)
+  end
+
+  @doc """
+  Check if cache is enabled.
+  """
+  def cache_enabled? do
+    Application.get_env(:ecosystem_manager, :enable_cache, false)
+  end
+
+  @doc """
+  Get cache TTL in milliseconds.
+  """
+  def cache_ttl do
+    Application.get_env(:ecosystem_manager, :cache_ttl, 300_000)
+  end
+
+  @doc """
+  Check if timing is enabled.
+  """
+  def timing_enabled? do
+    Application.get_env(:ecosystem_manager, :enable_timing, false)
+  end
+
+  @doc """
+  Get GitHub API base URL.
+  """
+  def github_api_base_url do
+    Application.get_env(:ecosystem_manager, :github_api_base_url, "https://api.github.com")
+  end
+
+  @doc """
+  Get default include GitHub setting.
+  """
+  def default_include_github do
+    Application.get_env(:ecosystem_manager, :default_include_github, true)
+  end
+
+  @doc """
+  Get workspace path configuration.
+  Returns nil if not configured.
+  """
+  def workspace_path do
+    Application.get_env(:ecosystem_manager, :workspace_path)
+  end
+
+  @doc """
+  Get repositories configuration.
+  Returns nil if not configured.
+  """
+  def repositories do
+    Application.get_env(:ecosystem_manager, :repositories)
+  end
+
+  @doc """
+  Get all configuration as a keyword list.
+  """
+  def all do
+    [
+      default_concurrency: default_concurrency(),
+      github_timeout: github_timeout(),
+      git_timeout: git_timeout(),
+      default_format: default_format(),
+      cache_enabled: cache_enabled?(),
+      cache_ttl: cache_ttl(),
+      timing_enabled: timing_enabled?(),
+      github_api_base_url: github_api_base_url(),
+      default_include_github: default_include_github(),
+      workspace_path: workspace_path(),
+      repositories: repositories()
+    ]
+  end
+end

--- a/ecosystem_manager/lib/ecosystem_manager/github.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/github.ex
@@ -213,10 +213,13 @@ defmodule EcosystemManager.GitHub do
     end)
   end
 
-  # Test helpers - exposed only for testing
+  # Test helpers - compiled only in the :test environment, so they never
+  # exist in production builds
   if Mix.env() == :test do
+    @doc false
     def test_count_by_labels(issues, target_labels), do: count_by_labels(issues, target_labels)
 
+    @doc false
     def test_process_issues_success(issues) do
       total = length(issues)
       bugs = count_by_labels(issues, ~w[bug error critical regression])
@@ -225,6 +228,7 @@ defmodule EcosystemManager.GitHub do
       %{total: total, bugs: bugs, enhancements: enhancements, urgent: urgent}
     end
 
+    @doc false
     def test_process_prs_success(prs) do
       total = length(prs)
       drafts = Enum.count(prs, & &1["isDraft"])

--- a/ecosystem_manager/lib/ecosystem_manager/repository.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/repository.ex
@@ -39,6 +39,7 @@ defmodule EcosystemManager.Repository do
     "sotsuron-report-template",
     "wr-template",
     "ise-report-template",
+    "poster-template",
     "latex-release-action",
     "thesis-management-tools",
     "thesis-student-registry",

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -1,0 +1,144 @@
+defmodule EcosystemManager.UserConfig do
+  @moduledoc """
+  User configuration file support for EcosystemManager.
+
+  Loads and manages user-specific configuration from ~/.config/ecosystem-manager/config.exs
+  """
+
+  @config_dir "~/.config/ecosystem-manager"
+  @config_file "config.exs"
+
+  @doc """
+  Load user configuration file if it exists.
+  Returns :ok if loaded successfully or if file doesn't exist.
+  Returns {:error, reason} if there's a problem loading the file.
+  """
+  def load do
+    config_path = get_config_path()
+
+    if File.exists?(config_path) do
+      try do
+        # Read the config file using Config.Reader
+        config_data = Config.Reader.read!(config_path)
+
+        # Apply the configuration to the application
+        if config_data[:ecosystem_manager] do
+          Enum.each(config_data[:ecosystem_manager], fn {key, value} ->
+            Application.put_env(:ecosystem_manager, key, value)
+          end)
+        end
+
+        :ok
+      rescue
+        e in [CompileError, SyntaxError] ->
+          {:error, "Invalid configuration file: #{Exception.message(e)}"}
+      catch
+        :error, reason ->
+          {:error, "Failed to load configuration: #{inspect(reason)}"}
+      end
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Get the full path to the user configuration file.
+  """
+  def get_config_path do
+    Path.join(Path.expand(@config_dir), @config_file)
+  end
+
+  @doc """
+  Get the user configuration directory path.
+  """
+  def get_config_dir do
+    Path.expand(@config_dir)
+  end
+
+  @doc """
+  Create example user configuration file.
+  """
+  def create_example_config do
+    config_dir = get_config_dir()
+    example_path = Path.join(config_dir, "config.example.exs")
+
+    # Ensure directory exists
+    File.mkdir_p!(config_dir)
+
+    example_content = """
+    # EcosystemManager User Configuration
+    # Copy this file to config.exs and customize as needed
+
+    import Config
+
+    # Set your LaTeX ecosystem workspace path
+    # This path will be used as the base directory for all operations
+    config :ecosystem_manager,
+      workspace_path: "~/SynologyDrive/semi/LaTeX/latex-ecosystem",
+      
+      # Optional: Override default repository list
+      # repositories: [
+      #   ".",
+      #   "texlive-ja-textlint", 
+      #   "latex-environment",
+      #   "sotsuron-template",
+      #   "my-custom-repo"
+      # ]
+
+    # You can override any other settings here
+    # config :ecosystem_manager,
+    #   default_concurrency: 4,
+    #   github_timeout: 30_000,
+    #   default_format: :long
+    """
+
+    case File.write(example_path, example_content) do
+      :ok ->
+        {:ok, example_path}
+
+      {:error, reason} ->
+        {:error, "Failed to create example config: #{reason}"}
+    end
+  end
+
+  @doc """
+  Create default user configuration file if it doesn't exist.
+  """
+  def create_default_config(workspace_path \\ nil) do
+    config_path = get_config_path()
+
+    if File.exists?(config_path) do
+      {:error, "Configuration file already exists: #{config_path}"}
+    else
+      config_dir = get_config_dir()
+      File.mkdir_p!(config_dir)
+
+      default_content = """
+      # EcosystemManager User Configuration
+      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
+
+      import Config
+
+      # Set your LaTeX ecosystem workspace path
+      config :ecosystem_manager,
+        workspace_path: #{inspect(workspace_path || "~/path/to/latex-ecosystem")},
+        
+        # Optional: Custom repository list
+        # repositories: [
+        #   ".",
+        #   "texlive-ja-textlint",
+        #   "latex-environment",
+        #   "sotsuron-template"
+        # ]
+      """
+
+      case File.write(config_path, default_content) do
+        :ok ->
+          {:ok, config_path}
+
+        {:error, reason} ->
+          {:error, "Failed to create config: #{reason}"}
+      end
+    end
+  end
+end

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -83,9 +83,12 @@ defmodule EcosystemManager.UserConfig do
     config_dir = get_config_dir()
     example_path = Path.join(config_dir, "config.example.exs")
 
-    # Ensure directory exists
-    File.mkdir_p!(config_dir)
+    with :ok <- ensure_config_dir(config_dir) do
+      write_example_config(example_path)
+    end
+  end
 
+  defp write_example_config(example_path) do
     example_content = """
     # EcosystemManager User Configuration
     # Copy this file to config.exs and customize as needed
@@ -135,35 +138,45 @@ defmodule EcosystemManager.UserConfig do
     if File.exists?(config_path) do
       {:error, "Configuration file already exists: #{config_path}"}
     else
-      config_dir = get_config_dir()
-      File.mkdir_p!(config_dir)
-
-      default_content = """
-      # EcosystemManager User Configuration
-      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
-
-      import Config
-
-      # Set your LaTeX ecosystem workspace path
-      config :ecosystem_manager,
-        workspace_path: #{inspect(workspace_path || "~/path/to/latex-ecosystem")},
-        
-        # Optional: Custom repository list
-        # repositories: [
-        #   ".",
-        #   "texlive-ja-textlint",
-        #   "latex-environment",
-        #   "sotsuron-template"
-        # ]
-      """
-
-      case File.write(config_path, default_content) do
-        :ok ->
-          {:ok, config_path}
-
-        {:error, reason} ->
-          {:error, "Failed to create config: #{reason}"}
+      with :ok <- ensure_config_dir(get_config_dir()) do
+        write_default_config(config_path, workspace_path)
       end
+    end
+  end
+
+  defp write_default_config(config_path, workspace_path) do
+    default_content = """
+    # EcosystemManager User Configuration
+    # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
+
+    import Config
+
+    # Set your LaTeX ecosystem workspace path
+    config :ecosystem_manager,
+      workspace_path: #{inspect(workspace_path || "~/path/to/latex-ecosystem")},
+      
+      # Optional: Custom repository list
+      # repositories: [
+      #   ".",
+      #   "texlive-ja-textlint",
+      #   "latex-environment",
+      #   "sotsuron-template"
+      # ]
+    """
+
+    case File.write(config_path, default_content) do
+      :ok ->
+        {:ok, config_path}
+
+      {:error, reason} ->
+        {:error, "Failed to create config: #{reason}"}
+    end
+  end
+
+  defp ensure_config_dir(config_dir) do
+    case File.mkdir_p(config_dir) do
+      :ok -> :ok
+      {:error, reason} -> {:error, "Failed to create config directory: #{reason}"}
     end
   end
 end

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -24,8 +24,10 @@ defmodule EcosystemManager.UserConfig do
       try do
         # Config.Reader.read!/1 is primarily meant for build-time config,
         # but works at runtime since Elixir 1.11. The config file must
-        # start with `import Config`; syntax or compile errors raised while
-        # evaluating it are converted to {:error, reason} below.
+        # start with `import Config` and must not use build-time-only
+        # constructs such as config_env/0 or import_config/1 (documented
+        # in config.example.exs). Any error raised while evaluating it is
+        # converted to {:error, reason} below.
         config_data = Config.Reader.read!(config_path)
 
         # Apply the configuration to the application
@@ -37,11 +39,13 @@ defmodule EcosystemManager.UserConfig do
 
         :ok
       rescue
-        e in [CompileError, SyntaxError] ->
+        # Any raised exception (syntax errors, compile errors, and whatever
+        # else evaluating user code may raise) becomes a readable message
+        e ->
           {:error, "Invalid configuration file: #{Exception.message(e)}"}
       catch
-        # Catch every kind (:error, :throw, :exit) so a misbehaving config
-        # file can never crash the CLI at startup.
+        # Non-raise exits: throw/exit from a misbehaving config file must
+        # not crash the CLI at startup either
         kind, reason ->
           {:error, "Failed to load configuration: #{inspect({kind, reason})}"}
       end
@@ -85,6 +89,10 @@ defmodule EcosystemManager.UserConfig do
     example_content = """
     # EcosystemManager User Configuration
     # Copy this file to config.exs and customize as needed
+    #
+    # This file is evaluated as Elixir code at runtime. Build-time-only
+    # constructs such as config_env/0 and import_config/1 are NOT
+    # available here.
 
     import Config
 

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -3,6 +3,10 @@ defmodule EcosystemManager.UserConfig do
   User configuration file support for EcosystemManager.
 
   Loads and manages user-specific configuration from ~/.config/ecosystem-manager/config.exs
+
+  Security note: the config file is evaluated as Elixir code with the
+  privileges of the CLI user. This is acceptable for a tool reading its
+  own per-user config file, but never point it at untrusted input.
   """
 
   @config_dir "~/.config/ecosystem-manager"
@@ -36,8 +40,10 @@ defmodule EcosystemManager.UserConfig do
         e in [CompileError, SyntaxError] ->
           {:error, "Invalid configuration file: #{Exception.message(e)}"}
       catch
-        :error, reason ->
-          {:error, "Failed to load configuration: #{inspect(reason)}"}
+        # Catch every kind (:error, :throw, :exit) so a misbehaving config
+        # file can never crash the CLI at startup.
+        kind, reason ->
+          {:error, "Failed to load configuration: #{inspect({kind, reason})}"}
       end
     else
       :ok

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -18,7 +18,10 @@ defmodule EcosystemManager.UserConfig do
 
     if File.exists?(config_path) do
       try do
-        # Read the config file using Config.Reader
+        # Config.Reader.read!/1 is primarily meant for build-time config,
+        # but works at runtime since Elixir 1.11. The config file must
+        # start with `import Config`; syntax or compile errors raised while
+        # evaluating it are converted to {:error, reason} below.
         config_data = Config.Reader.read!(config_path)
 
         # Apply the configuration to the application
@@ -45,14 +48,22 @@ defmodule EcosystemManager.UserConfig do
   Get the full path to the user configuration file.
   """
   def get_config_path do
-    Path.join(Path.expand(@config_dir), @config_file)
+    Path.join(get_config_dir(), @config_file)
   end
 
   @doc """
   Get the user configuration directory path.
+
+  Honors the ECOSYSTEM_MANAGER_CONFIG_DIR environment variable when set
+  (used by tests and useful for CI); falls back to #{@config_dir}.
+  Note: HOME changes at runtime do not affect the fallback because
+  Path.expand/1 resolves `~` via the home directory cached at VM start.
   """
   def get_config_dir do
-    Path.expand(@config_dir)
+    case System.get_env("ECOSYSTEM_MANAGER_CONFIG_DIR") do
+      nil -> Path.expand(@config_dir)
+      dir -> Path.expand(dir)
+    end
   end
 
   @doc """

--- a/ecosystem_manager/test/cli_test.exs
+++ b/ecosystem_manager/test/cli_test.exs
@@ -1,0 +1,322 @@
+defmodule EcosystemManager.CLITest do
+  use ExUnit.Case
+  doctest EcosystemManager.CLI
+
+  alias EcosystemManager.CLI
+
+  describe "parse_args/1" do
+    test "parses help flag" do
+      result = CLI.parse_args(["--help"])
+      assert result.opts[:help] == true
+      assert result.command == "status"
+    end
+
+    test "parses command" do
+      result = CLI.parse_args(["status"])
+      assert result.command == "status"
+    end
+
+    test "parses options" do
+      result = CLI.parse_args(["status", "--long", "--fast"])
+      assert result.opts[:long] == true
+      assert result.opts[:fast] == true
+    end
+
+    test "defaults to status command" do
+      result = CLI.parse_args([])
+      assert result.command == "status"
+    end
+
+    test "handles unknown command" do
+      result = CLI.parse_args(["unknown"])
+      assert result.command == "unknown"
+    end
+
+    test "parses max_concurrency option" do
+      result = CLI.parse_args(["status", "--max-concurrency", "12"])
+      assert result.opts[:max_concurrency] == 12
+    end
+
+    test "parses filter options" do
+      result = CLI.parse_args(["status", "--urgent-issues", "--with-prs", "--needs-review"])
+      assert result.opts[:urgent_issues] == true
+      assert result.opts[:with_prs] == true
+      assert result.opts[:needs_review] == true
+    end
+
+    test "handles aliases" do
+      result = CLI.parse_args(["-h", "-l", "-f"])
+      assert result.opts[:help] == true
+      assert result.opts[:long] == true
+      assert result.opts[:fast] == true
+    end
+
+    test "parses time sort option" do
+      result = CLI.parse_args(["status", "--time-sort"])
+      assert result.opts[:time_sort] == true
+    end
+
+    test "parses time sort alias" do
+      result = CLI.parse_args(["status", "-t"])
+      assert result.opts[:time_sort] == true
+    end
+
+    test "includes base_path in result" do
+      result = CLI.parse_args(["status"])
+      assert is_binary(result.base_path)
+    end
+  end
+
+  describe "build_filters/1" do
+    test "builds empty filters for no options" do
+      filters = CLI.build_filters([])
+      assert filters == []
+    end
+
+    test "builds filters for urgent issues" do
+      filters = CLI.build_filters(urgent_issues: true)
+      assert {:urgent_issues_only, true} in filters
+    end
+
+    test "builds filters for PRs" do
+      filters = CLI.build_filters(with_prs: true)
+      assert {:with_prs_only, true} in filters
+    end
+
+    test "builds filters for needs review" do
+      filters = CLI.build_filters(needs_review: true)
+      assert {:needs_review_only, true} in filters
+    end
+
+    test "builds multiple filters" do
+      filters = CLI.build_filters(urgent_issues: true, with_prs: true)
+      assert {:urgent_issues_only, true} in filters
+      assert {:with_prs_only, true} in filters
+    end
+
+    test "ignores false values" do
+      filters = CLI.build_filters(urgent_issues: false, with_prs: true)
+      assert {:urgent_issues_only, true} not in filters
+      assert {:with_prs_only, true} in filters
+    end
+  end
+
+  describe "find_ecosystem_root/1" do
+    test "finds root with marker file" do
+      temp_dir = System.tmp_dir!()
+      test_dir = Path.join(temp_dir, "test_ecosystem_#{:rand.uniform(10_000)}")
+      File.mkdir_p!(test_dir)
+      marker_file = Path.join(test_dir, "ecosystem-manager.sh")
+      File.write!(marker_file, "#!/bin/bash\necho test")
+
+      try do
+        result = CLI.find_ecosystem_root(test_dir)
+        assert result == test_dir
+      after
+        File.rm_rf!(test_dir)
+      end
+    end
+
+    test "returns nil when no marker found" do
+      temp_dir = System.tmp_dir!()
+      test_dir = Path.join(temp_dir, "no_marker_#{:rand.uniform(10_000)}")
+      File.mkdir_p!(test_dir)
+
+      try do
+        result = CLI.find_ecosystem_root(test_dir)
+        assert result == nil
+      after
+        File.rm_rf!(test_dir)
+      end
+    end
+
+    test "traverses up directory tree" do
+      temp_dir = System.tmp_dir!()
+      deep_path = Path.join(temp_dir, "level1/level2/level3/level4")
+      File.mkdir_p!(deep_path)
+      marker_path = Path.join(temp_dir, "level1/level2")
+      marker_file = Path.join(marker_path, "ecosystem-manager.sh")
+      File.write!(marker_file, "#!/bin/bash\necho test")
+
+      try do
+        result = CLI.find_ecosystem_root(deep_path)
+        assert result == marker_path
+      after
+        File.rm_rf!(Path.join(temp_dir, "level1"))
+      end
+    end
+  end
+
+  describe "get_base_path with workspace_path config" do
+    test "base_path uses find_ecosystem_root when workspace_path not configured" do
+      # With default config (workspace_path: nil), it should use current directory logic
+      result = CLI.parse_args(["status"])
+      assert is_binary(result.base_path)
+    end
+
+    test "base_path validation" do
+      # Parse args should always provide a base_path
+      result = CLI.parse_args(["status"])
+      assert Map.has_key?(result, :base_path)
+      assert is_binary(result.base_path)
+
+      # If it's not the current directory, it should be an absolute path
+      if result.base_path != "." do
+        assert Path.type(result.base_path) == :absolute
+      end
+    end
+  end
+
+  describe "argument parsing edge cases" do
+    test "handles empty string arguments" do
+      result = CLI.parse_args([""])
+      assert result.command == ""
+      assert is_list(result.opts)
+      assert is_binary(result.base_path)
+    end
+
+    test "handles max-concurrency without value" do
+      result = CLI.parse_args(["status", "--max-concurrency"])
+      assert result.command == "status"
+      assert is_nil(result.opts[:max_concurrency])
+    end
+
+    test "handles unknown flags" do
+      result = CLI.parse_args(["status", "--unknown-flag"])
+      assert result.command == "status"
+      assert is_list(result.opts)
+    end
+  end
+
+  describe "all supported commands" do
+    test "parses config command" do
+      result = CLI.parse_args(["config"])
+      assert result.command == "config"
+    end
+
+    test "parses repos command" do
+      result = CLI.parse_args(["repos"])
+      assert result.command == "repos"
+    end
+
+    test "parses init-config command" do
+      result = CLI.parse_args(["init-config"])
+      assert result.command == "init-config"
+    end
+
+    test "parses help command" do
+      result = CLI.parse_args(["help"])
+      assert result.command == "help"
+    end
+
+    test "parses workspace command" do
+      result = CLI.parse_args(["workspace"])
+      assert result.command == "workspace"
+    end
+  end
+
+  describe "filter combinations" do
+    test "handles all filter combinations" do
+      filter_opts = [
+        [urgent_issues: true],
+        [with_prs: true],
+        [needs_review: true],
+        [urgent_issues: true, with_prs: true],
+        [urgent_issues: true, needs_review: true],
+        [with_prs: true, needs_review: true],
+        [urgent_issues: true, with_prs: true, needs_review: true]
+      ]
+
+      for opts <- filter_opts do
+        filters = CLI.build_filters(opts)
+        assert is_list(filters)
+        expected_count = Enum.count(opts, fn {_k, v} -> v end)
+        assert length(filters) == expected_count
+      end
+    end
+  end
+
+  describe "main/1 integration" do
+    test "executes help command" do
+      # Capture IO to verify output
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["help"])
+        end)
+
+      assert String.contains?(result, "LaTeX Thesis Environment Ecosystem Manager")
+      assert String.contains?(result, "USAGE:")
+      assert String.contains?(result, "COMMANDS:")
+    end
+
+    test "executes help flag" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["--help"])
+        end)
+
+      assert String.contains?(result, "LaTeX Thesis Environment Ecosystem Manager")
+    end
+
+    test "executes config command" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["config"])
+        end)
+
+      assert String.contains?(result, "EcosystemManager Configuration")
+    end
+
+    test "executes repos command" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["repos"])
+        end)
+
+      assert String.contains?(result, "Repository Configuration")
+    end
+
+    test "executes init-config command" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["init-config"])
+        end)
+
+      assert String.contains?(result, "Initializing user configuration")
+    end
+
+    test "executes workspace command" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["workspace"])
+        end)
+
+      # Should output a path (either configured workspace_path or detected base_path)
+      trimmed_result = String.trim(result)
+      assert trimmed_result != ""
+      assert String.length(trimmed_result) > 0
+      # Should be an absolute path
+      assert String.starts_with?(trimmed_result, "/")
+    end
+
+    test "executes status command with fast mode" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          CLI.main(["status", "--fast"])
+        end)
+
+      assert String.contains?(result, "Repository Status Overview")
+      assert String.contains?(result, "Fast mode")
+    end
+
+    test "handles unknown command with exit" do
+      result =
+        ExUnit.CaptureIO.capture_io(fn ->
+          assert catch_exit(CLI.main(["unknown"])) == {:shutdown, 1}
+        end)
+
+      assert String.contains?(result, "Unknown command: unknown")
+      assert String.contains?(result, "Run 'ecosystem-manager help' for usage information.")
+    end
+  end
+end

--- a/ecosystem_manager/test/ecosystem_manager/config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/config_test.exs
@@ -98,15 +98,27 @@ defmodule EcosystemManager.ConfigTest do
   end
 
   describe "runtime configuration changes" do
-    test "configuration can be changed at runtime" do
-      # Change concurrency
-      original_concurrency = Config.default_concurrency()
+    setup do
+      # Snapshot and always restore, even when an assertion fails midway
+      original = Application.get_env(:ecosystem_manager, :default_concurrency)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:ecosystem_manager, :default_concurrency, original)
+        else
+          Application.delete_env(:ecosystem_manager, :default_concurrency)
+        end
+      end)
+
+      %{original_concurrency: Config.default_concurrency()}
+    end
+
+    test "configuration can be changed at runtime", %{original_concurrency: original} do
       Application.put_env(:ecosystem_manager, :default_concurrency, 16)
       assert Config.default_concurrency() == 16
 
-      # Restore original value
-      Application.put_env(:ecosystem_manager, :default_concurrency, original_concurrency)
-      assert Config.default_concurrency() == original_concurrency
+      Application.put_env(:ecosystem_manager, :default_concurrency, original)
+      assert Config.default_concurrency() == original
     end
   end
 end

--- a/ecosystem_manager/test/ecosystem_manager/config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/config_test.exs
@@ -1,0 +1,101 @@
+defmodule EcosystemManager.ConfigTest do
+  use ExUnit.Case
+  doctest EcosystemManager.Config
+
+  alias EcosystemManager.Config
+
+  describe "configuration access" do
+    test "default_concurrency/0 returns configured or default value" do
+      assert Config.default_concurrency() == 8
+    end
+
+    test "github_timeout/0 returns configured or default value" do
+      assert Config.github_timeout() == 15_000
+    end
+
+    test "git_timeout/0 returns configured or default value" do
+      assert Config.git_timeout() == 5_000
+    end
+
+    test "default_format/0 returns configured or default value" do
+      assert Config.default_format() == :compact
+    end
+
+    test "cache_enabled?/0 returns configured or default value" do
+      assert Config.cache_enabled?() == false
+    end
+
+    test "cache_ttl/0 returns configured or default value" do
+      assert Config.cache_ttl() == 300_000
+    end
+
+    test "timing_enabled?/0 returns configured or default value" do
+      assert Config.timing_enabled?() == false
+    end
+
+    test "github_api_base_url/0 returns configured or default value" do
+      assert Config.github_api_base_url() == "https://api.github.com"
+    end
+
+    test "default_include_github/0 returns configured or default value" do
+      assert Config.default_include_github() == true
+    end
+
+    test "all/0 returns all configuration as keyword list" do
+      config = Config.all()
+
+      assert Keyword.has_key?(config, :default_concurrency)
+      assert Keyword.has_key?(config, :github_timeout)
+      assert Keyword.has_key?(config, :git_timeout)
+      assert Keyword.has_key?(config, :default_format)
+      assert Keyword.has_key?(config, :cache_enabled)
+      assert Keyword.has_key?(config, :cache_ttl)
+      assert Keyword.has_key?(config, :timing_enabled)
+      assert Keyword.has_key?(config, :github_api_base_url)
+      assert Keyword.has_key?(config, :default_include_github)
+      assert Keyword.has_key?(config, :workspace_path)
+      assert Keyword.has_key?(config, :repositories)
+    end
+  end
+
+  describe "repositories configuration" do
+    test "repositories/0 returns configured repositories or nil" do
+      result = Config.repositories()
+
+      # Should be either nil or a list
+      assert is_nil(result) or is_list(result)
+    end
+  end
+
+  describe "configuration fallbacks" do
+    test "functions return defaults when application config is missing" do
+      # Test that functions work even when specific config is not set
+      Application.delete_env(:ecosystem_manager, :default_concurrency)
+      assert Config.default_concurrency() == 8
+
+      Application.delete_env(:ecosystem_manager, :github_timeout)
+      assert Config.github_timeout() == 15_000
+
+      Application.delete_env(:ecosystem_manager, :default_format)
+      assert Config.default_format() == :compact
+
+      # Restore configuration
+      Application.put_env(:ecosystem_manager, :default_concurrency, 8)
+      Application.put_env(:ecosystem_manager, :github_timeout, 15_000)
+      Application.put_env(:ecosystem_manager, :default_format, :compact)
+    end
+  end
+
+  describe "runtime configuration changes" do
+    test "configuration can be changed at runtime" do
+      # Change concurrency
+      original_concurrency = Config.default_concurrency()
+      Application.put_env(:ecosystem_manager, :default_concurrency, 16)
+      assert Config.default_concurrency() == 16
+
+      # Restore original value
+      Application.put_env(:ecosystem_manager, :default_concurrency, original_concurrency)
+      assert Config.default_concurrency() == original_concurrency
+    end
+  end
+end

--- a/ecosystem_manager/test/ecosystem_manager/config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/config_test.exs
@@ -68,6 +68,22 @@ defmodule EcosystemManager.ConfigTest do
   end
 
   describe "configuration fallbacks" do
+    setup do
+      # Snapshot and always restore the application env, even when an
+      # assertion in the test fails midway
+      keys = [:default_concurrency, :github_timeout, :default_format]
+      originals = Enum.map(keys, &{&1, Application.get_env(:ecosystem_manager, &1)})
+
+      on_exit(fn ->
+        Enum.each(originals, fn
+          {key, nil} -> Application.delete_env(:ecosystem_manager, key)
+          {key, value} -> Application.put_env(:ecosystem_manager, key, value)
+        end)
+      end)
+
+      :ok
+    end
+
     test "functions return defaults when application config is missing" do
       # Test that functions work even when specific config is not set
       Application.delete_env(:ecosystem_manager, :default_concurrency)
@@ -78,11 +94,6 @@ defmodule EcosystemManager.ConfigTest do
 
       Application.delete_env(:ecosystem_manager, :default_format)
       assert Config.default_format() == :compact
-
-      # Restore configuration
-      Application.put_env(:ecosystem_manager, :default_concurrency, 8)
-      Application.put_env(:ecosystem_manager, :github_timeout, 15_000)
-      Application.put_env(:ecosystem_manager, :default_format, :compact)
     end
   end
 

--- a/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
@@ -1,0 +1,58 @@
+defmodule EcosystemManager.RepositoryConfigTest do
+  use ExUnit.Case
+
+  alias EcosystemManager.Repository
+
+  describe "repository configuration" do
+    test "default_repositories/0 returns the built-in list" do
+      defaults = Repository.default_repositories()
+      assert is_list(defaults)
+      assert "." in defaults
+      assert "texlive-ja-textlint" in defaults
+      assert length(defaults) > 5
+    end
+
+    test "default_repositories/0 includes all ecosystem template repositories" do
+      defaults = Repository.default_repositories()
+
+      for template <- [
+            "sotsuron-template",
+            "latex-template",
+            "sotsuron-report-template",
+            "wr-template",
+            "ise-report-template",
+            "poster-template"
+          ] do
+        assert template in defaults
+      end
+    end
+
+    test "get_configured_repositories/0 returns config value" do
+      result = Repository.get_configured_repositories()
+      # Should be either nil or a list
+      assert is_nil(result) or is_list(result)
+    end
+
+    test "all_repositories/0 falls back to defaults when no config exists" do
+      repos = Repository.all_repositories()
+      assert is_list(repos)
+      assert length(repos) > 0
+    end
+
+    test "all_repositories/0 is deterministic" do
+      repos1 = Repository.all_repositories()
+      repos2 = Repository.all_repositories()
+      assert repos1 == repos2
+    end
+
+    test "default_repositories/0 is stable" do
+      defaults1 = Repository.default_repositories()
+      defaults2 = Repository.default_repositories()
+
+      assert defaults1 == defaults2
+      assert is_list(defaults1)
+      assert "." in defaults1
+      assert length(defaults1) > 0
+    end
+  end
+end

--- a/ecosystem_manager/test/github_test.exs
+++ b/ecosystem_manager/test/github_test.exs
@@ -773,6 +773,10 @@ defmodule EcosystemManager.GitHubTest do
         File.mkdir_p!(test_repo)
 
         System.cmd("git", ["init"], cd: test_repo)
+        # Some git versions reject unusual URLs (e.g. the empty string).
+        # That is fine for this test: whether the remote is added with a
+        # non-GitHub URL or not added at all, get_github_remote/1 must
+        # return :error either way.
         System.cmd("git", ["remote", "add", "origin", url], cd: test_repo)
 
         try do

--- a/ecosystem_manager/test/github_test.exs
+++ b/ecosystem_manager/test/github_test.exs
@@ -1,0 +1,907 @@
+defmodule EcosystemManager.GitHubTest do
+  use ExUnit.Case
+  doctest EcosystemManager.GitHub
+
+  alias EcosystemManager.{GitHub, Repository}
+
+  describe "get_github_remote function" do
+    test "handles non-existent repository" do
+      temp_dir = System.tmp_dir!()
+      repo = %Repository{path: temp_dir}
+      result = GitHub.get_github_remote(repo)
+      assert result == :error
+    end
+
+    test "handles repository without remote" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "test_repo_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+
+      # Initialize git repository without remote
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = %Repository{path: test_repo}
+        result = GitHub.get_github_remote(repo)
+        assert result == :error
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "extracts owner and repo from GitHub URL" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "github_repo_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+
+      # Initialize git repository with GitHub remote
+      System.cmd("git", ["init"], cd: test_repo)
+
+      System.cmd("git", ["remote", "add", "origin", "https://github.com/user/repo.git"],
+        cd: test_repo
+      )
+
+      try do
+        repo = %Repository{path: test_repo}
+        result = GitHub.get_github_remote(repo)
+        assert result == {:ok, {"user", "repo"}}
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "handles SSH GitHub URLs" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "ssh_repo_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+
+      System.cmd("git", ["init"], cd: test_repo)
+
+      System.cmd("git", ["remote", "add", "origin", "git@github.com:user/repo.git"],
+        cd: test_repo
+      )
+
+      try do
+        repo = %Repository{path: test_repo}
+        result = GitHub.get_github_remote(repo)
+        assert result == {:ok, {"user", "repo"}}
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "get_pull_requests function" do
+    test "returns default info for owner/repo" do
+      result = GitHub.get_pull_requests("owner", "repo")
+      assert is_map(result)
+      assert Map.has_key?(result, :total)
+      assert Map.has_key?(result, :drafts)
+      assert Map.has_key?(result, :needs_review)
+    end
+
+    test "processes JSON data from successful gh command" do
+      # Test with various JSON structures that could come from gh
+      test_json_data = [
+        # Case 1: Empty PR list
+        "[]",
+        # Case 2: PRs with different states
+        """
+        [
+          {"isDraft": true, "reviewDecision": ""},
+          {"isDraft": false, "reviewDecision": "REVIEW_REQUIRED"},
+          {"isDraft": false, "reviewDecision": "APPROVED"},
+          {"isDraft": true, "reviewDecision": "CHANGES_REQUESTED"}
+        ]
+        """,
+        # Case 3: Mixed data
+        """
+        [
+          {"isDraft": false, "reviewDecision": "REVIEW_REQUIRED"},
+          {"isDraft": false, "reviewDecision": "REVIEW_REQUIRED"},
+          {"isDraft": true, "reviewDecision": ""},
+          {"isDraft": false, "reviewDecision": "APPROVED"}
+        ]
+        """
+      ]
+
+      for json_data <- test_json_data do
+        # This simulates what would happen if gh command succeeded
+        parsed_data = Jason.decode!(json_data)
+
+        # Test count_by_labels logic manually since it's private
+        total = length(parsed_data)
+        drafts = Enum.count(parsed_data, & &1["isDraft"])
+
+        needs_review =
+          Enum.count(parsed_data, fn pr ->
+            !pr["isDraft"] && pr["reviewDecision"] == "REVIEW_REQUIRED"
+          end)
+
+        # Verify the counting logic works correctly
+        assert is_integer(total)
+        assert is_integer(drafts)
+        assert is_integer(needs_review)
+        assert drafts >= 0
+        assert needs_review >= 0
+        assert total >= drafts
+      end
+    end
+  end
+
+  describe "get_issues function" do
+    test "returns default info for owner/repo" do
+      result = GitHub.get_issues("owner", "repo")
+      assert is_map(result)
+      assert Map.has_key?(result, :total)
+      assert Map.has_key?(result, :bugs)
+      assert Map.has_key?(result, :enhancements)
+      assert Map.has_key?(result, :urgent)
+    end
+
+    test "processes JSON data from successful gh command" do
+      # Test with various JSON structures that could come from gh
+      test_json_data = [
+        # Case 1: Empty issues list
+        "[]",
+        # Case 2: Issues with different labels
+        """
+        [
+          {"labels": [{"name": "bug"}, {"name": "critical"}]},
+          {"labels": [{"name": "enhancement"}, {"name": "feature"}]},
+          {"labels": [{"name": "urgent"}, {"name": "high"}]},
+          {"labels": [{"name": "documentation"}]}
+        ]
+        """,
+        # Case 3: Issues with no labels or mixed
+        """
+        [
+          {"labels": []},
+          {"labels": [{"name": "bug"}]},
+          {"labels": [{"name": "enhancement"}, {"name": "urgent"}]},
+          {"labels": [{"name": "bug"}, {"name": "urgent"}]}
+        ]
+        """
+      ]
+
+      for json_data <- test_json_data do
+        # This simulates what would happen if gh command succeeded
+        parsed_data = Jason.decode!(json_data)
+
+        # Test count_by_labels logic manually since it's private
+        total = length(parsed_data)
+
+        bugs =
+          Enum.count(parsed_data, fn issue ->
+            issue["labels"] |> Enum.any?(fn label -> label["name"] == "bug" end)
+          end)
+
+        enhancements =
+          Enum.count(parsed_data, fn issue ->
+            issue["labels"] |> Enum.any?(fn label -> label["name"] == "enhancement" end)
+          end)
+
+        urgent =
+          Enum.count(parsed_data, fn issue ->
+            issue["labels"] |> Enum.any?(fn label -> label["name"] == "urgent" end)
+          end)
+
+        # Verify the counting logic works correctly
+        assert is_integer(total)
+        assert is_integer(bugs)
+        assert is_integer(enhancements)
+        assert is_integer(urgent)
+        assert bugs >= 0
+        assert enhancements >= 0
+        assert urgent >= 0
+      end
+    end
+  end
+
+  describe "fetch_github_info function" do
+    test "handles repository without GitHub remote" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "no_github_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = %Repository{path: test_repo, name: "test"}
+        result = GitHub.fetch_github_info(repo)
+
+        assert is_map(result.issues)
+        assert is_map(result.pull_requests)
+        assert result.issues.total == 0
+        assert result.pull_requests.total == 0
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "private function coverage" do
+    test "parse_github_url with various formats" do
+      # Note: Testing through public interface since parse_github_url is private
+      url_test_cases = [
+        {"https://github.com/owner/repo.git", {:ok, {"owner", "repo"}}},
+        {"https://github.com/owner/repo", {:ok, {"owner", "repo"}}},
+        {"git@github.com:owner/repo.git", {:ok, {"owner", "repo"}}},
+        {"git@github.com:owner/repo", {:ok, {"owner", "repo"}}},
+        {"https://gitlab.com/owner/repo.git", :error},
+        {"https://bitbucket.org/owner/repo.git", :error},
+        {"invalid-url", :error},
+        {"", :error},
+        {"not-a-git-url", :error}
+      ]
+
+      temp_dir = System.tmp_dir!()
+
+      for {url, expected} <- url_test_cases do
+        test_repo = Path.join(temp_dir, "parse_test_#{:rand.uniform(10000)}")
+        File.mkdir_p!(test_repo)
+        System.cmd("git", ["init"], cd: test_repo)
+
+        if url != "" do
+          System.cmd("git", ["remote", "add", "origin", url], cd: test_repo)
+        end
+
+        try do
+          repo = %Repository{path: test_repo}
+          result = GitHub.get_github_remote(repo)
+          assert result == expected
+        after
+          File.rm_rf!(test_repo)
+        end
+      end
+    end
+
+    test "fetch_github_info with different repository states" do
+      temp_dir = System.tmp_dir!()
+
+      # Test with non-existent repository
+      non_existent = %Repository{path: "/non/existent", name: "test"}
+      result1 = GitHub.fetch_github_info(non_existent)
+      assert result1.issues.total == 0
+      assert result1.pull_requests.total == 0
+
+      # Test with repository without GitHub remote
+      no_remote_path = Path.join(temp_dir, "no_remote_#{:rand.uniform(10000)}")
+      File.mkdir_p!(no_remote_path)
+      System.cmd("git", ["init"], cd: no_remote_path)
+
+      try do
+        no_remote = %Repository{path: no_remote_path, name: "test"}
+        result2 = GitHub.fetch_github_info(no_remote)
+        assert result2.issues.total == 0
+        assert result2.pull_requests.total == 0
+      after
+        File.rm_rf!(no_remote_path)
+      end
+
+      # Test with repository with GitHub remote (will use default due to gh command failure)
+      github_path = Path.join(temp_dir, "github_#{:rand.uniform(10000)}")
+      File.mkdir_p!(github_path)
+      System.cmd("git", ["init"], cd: github_path)
+
+      System.cmd("git", ["remote", "add", "origin", "https://github.com/test/repo.git"],
+        cd: github_path
+      )
+
+      try do
+        github_repo = %Repository{path: github_path, name: "test"}
+        result3 = GitHub.fetch_github_info(github_repo)
+        # Should have default values due to gh command not being available
+        assert is_map(result3.issues)
+        assert is_map(result3.pull_requests)
+      after
+        File.rm_rf!(github_path)
+      end
+    end
+
+    test "count_by_labels function coverage" do
+      # Test issues/PRs data structures that would exercise count_by_labels
+      _test_issues = [
+        %{
+          "number" => 1,
+          "title" => "Bug fix",
+          "labels" => [
+            %{"name" => "bug"},
+            %{"name" => "critical"}
+          ]
+        },
+        %{
+          "number" => 2,
+          "title" => "Feature request",
+          "labels" => [
+            %{"name" => "enhancement"},
+            %{"name" => "feature"}
+          ]
+        },
+        %{
+          "number" => 3,
+          "title" => "Urgent issue",
+          "labels" => [
+            %{"name" => "urgent"},
+            %{"name" => "high"}
+          ]
+        },
+        %{
+          "number" => 4,
+          "title" => "No labels",
+          "labels" => []
+        },
+        %{
+          "number" => 5,
+          "title" => "Nil labels",
+          "labels" => nil
+        }
+      ]
+
+      # Test get_issues with mock data (will fail but exercise the function)
+      result = GitHub.get_issues("test", "repo")
+      assert is_map(result)
+      assert Map.has_key?(result, :total)
+      assert Map.has_key?(result, :bugs)
+      assert Map.has_key?(result, :enhancements)
+      assert Map.has_key?(result, :urgent)
+    end
+
+    test "simulates successful GitHub API calls with comprehensive data" do
+      # Test scenarios that would exercise success paths
+      # These test the logic that would run if gh commands succeeded
+
+      # Scenario 1: Repository with comprehensive issue data
+      issue_data = [
+        %{
+          "number" => 1,
+          "title" => "Critical bug in authentication",
+          "labels" => [
+            %{"name" => "bug"},
+            %{"name" => "critical"},
+            %{"name" => "urgent"}
+          ]
+        },
+        %{
+          "number" => 2,
+          "title" => "Feature request for dark mode",
+          "labels" => [
+            %{"name" => "enhancement"},
+            %{"name" => "feature"},
+            %{"name" => "ui"}
+          ]
+        },
+        %{
+          "number" => 3,
+          "title" => "High priority performance issue",
+          "labels" => [
+            %{"name" => "bug"},
+            %{"name" => "performance"},
+            %{"name" => "high"}
+          ]
+        },
+        %{
+          "number" => 4,
+          "title" => "Documentation improvement",
+          "labels" => [
+            %{"name" => "documentation"},
+            %{"name" => "improvement"}
+          ]
+        },
+        %{
+          "number" => 5,
+          "title" => "Issue with empty labels",
+          "labels" => []
+        },
+        %{
+          "number" => 6,
+          "title" => "Issue with nil labels",
+          "labels" => nil
+        }
+      ]
+
+      # Test count_by_labels logic manually
+      total = length(issue_data)
+
+      bugs =
+        Enum.count(issue_data, fn issue ->
+          labels = issue["labels"] || []
+
+          Enum.any?(labels, fn label ->
+            label_name = String.downcase(label["name"] || "")
+            Enum.any?(~w[bug error critical regression], &String.contains?(label_name, &1))
+          end)
+        end)
+
+      enhancements =
+        Enum.count(issue_data, fn issue ->
+          labels = issue["labels"] || []
+
+          Enum.any?(labels, fn label ->
+            label_name = String.downcase(label["name"] || "")
+
+            Enum.any?(
+              ~w[enhancement feature improvement request],
+              &String.contains?(label_name, &1)
+            )
+          end)
+        end)
+
+      urgent =
+        Enum.count(issue_data, fn issue ->
+          labels = issue["labels"] || []
+
+          Enum.any?(labels, fn label ->
+            label_name = String.downcase(label["name"] || "")
+            Enum.any?(~w[critical urgent high], &String.contains?(label_name, &1))
+          end)
+        end)
+
+      # Verify counting logic
+      assert total == 6
+      # Issues 1 and 3 have bug labels
+      assert bugs == 2
+      # Issues 2 and 4 have enhancement-type labels
+      assert enhancements == 2
+      # Issues 1 and 3 have urgent/critical/high labels
+      assert urgent == 2
+
+      # Scenario 2: Repository with PR data
+      pr_data = [
+        %{
+          "number" => 1,
+          "title" => "Fix authentication bug",
+          "isDraft" => false,
+          "reviewDecision" => "REVIEW_REQUIRED"
+        },
+        %{
+          "number" => 2,
+          "title" => "Draft: WIP feature",
+          "isDraft" => true,
+          "reviewDecision" => nil
+        },
+        %{
+          "number" => 3,
+          "title" => "Approved changes",
+          "isDraft" => false,
+          "reviewDecision" => "APPROVED"
+        },
+        %{
+          "number" => 4,
+          "title" => "Another draft",
+          "isDraft" => true,
+          "reviewDecision" => "CHANGES_REQUESTED"
+        },
+        %{
+          "number" => 5,
+          "title" => "Needs review",
+          "isDraft" => false,
+          "reviewDecision" => nil
+        }
+      ]
+
+      # Test PR counting logic
+      pr_total = length(pr_data)
+      pr_drafts = Enum.count(pr_data, & &1["isDraft"])
+
+      pr_needs_review =
+        Enum.count(pr_data, fn pr ->
+          not pr["isDraft"] and pr["reviewDecision"] in [nil, "REVIEW_REQUIRED"]
+        end)
+
+      # Verify PR counting logic
+      assert pr_total == 5
+      # PRs 2 and 4 are drafts
+      assert pr_drafts == 2
+      # PRs 1 and 5 need review
+      assert pr_needs_review == 2
+
+      # These tests verify the logic that would be executed in the success paths
+      # of get_issues and get_pull_requests functions
+    end
+
+    test "gh_api_call error handling" do
+      # Test various gh command scenarios
+      # These will fail but exercise error handling paths
+
+      # Test get_issues with non-existent repo
+      result1 = GitHub.get_issues("nonexistent", "repo")
+      assert result1.total == 0
+      assert result1.bugs == 0
+      assert result1.enhancements == 0
+      assert result1.urgent == 0
+
+      # Test get_pull_requests with non-existent repo
+      result2 = GitHub.get_pull_requests("nonexistent", "repo")
+      assert result2.total == 0
+      assert result2.drafts == 0
+      assert result2.needs_review == 0
+
+      # Test with various invalid input combinations
+      invalid_inputs = [
+        {"", ""},
+        {"a", "b"},
+        {"test-owner", "test-repo"},
+        {"user/repo", "invalid"},
+        {"./local", "path"}
+      ]
+
+      for {owner, repo} <- invalid_inputs do
+        issues = GitHub.get_issues(owner, repo)
+        prs = GitHub.get_pull_requests(owner, repo)
+
+        assert is_map(issues)
+        assert is_map(prs)
+        assert issues.total == 0
+        assert prs.total == 0
+      end
+    end
+
+    test "mock successful GitHub API responses" do
+      # Since we can't easily mock System.cmd in tests without additional libraries,
+      # we'll create a test that exercises the success path logic manually
+      # by simulating what would happen if gh commands succeeded
+
+      # This tests the JSON parsing and counting logic that would run
+      # in the success paths of get_issues and get_pull_requests
+
+      # Test issue counting logic with mock data
+      mock_issues_json = """
+      [
+        {"number": 1, "title": "Critical bug", "labels": [{"name": "bug"}, {"name": "critical"}]},
+        {"number": 2, "title": "Feature request", "labels": [{"name": "enhancement"}]},
+        {"number": 3, "title": "Urgent fix", "labels": [{"name": "urgent"}, {"name": "bug"}]},
+        {"number": 4, "title": "No labels", "labels": []},
+        {"number": 5, "title": "Enhancement", "labels": [{"name": "feature"}]}
+      ]
+      """
+
+      # Test PR counting logic with mock data
+      mock_prs_json = """
+      [
+        {"number": 1, "title": "Fix bug", "isDraft": false, "reviewDecision": "REVIEW_REQUIRED"},
+        {"number": 2, "title": "Draft PR", "isDraft": true, "reviewDecision": null},
+        {"number": 3, "title": "Approved", "isDraft": false, "reviewDecision": "APPROVED"},
+        {"number": 4, "title": "Needs review", "isDraft": false, "reviewDecision": null}
+      ]
+      """
+
+      # Parse JSON (this simulates successful Jason.decode)
+      {:ok, issues_data} = Jason.decode(mock_issues_json)
+      {:ok, prs_data} = Jason.decode(mock_prs_json)
+
+      # Test the actual success path logic using test helpers
+      issues_result = GitHub.test_process_issues_success(issues_data)
+      prs_result = GitHub.test_process_prs_success(prs_data)
+
+      # Verify issue counting logic
+      assert issues_result.total == 5
+      # Issues 1 and 3 have bug labels
+      assert issues_result.bugs == 2
+      # Issues 2 and 5 have enhancement labels
+      assert issues_result.enhancements == 2
+      # Issues 1 and 3 have urgent/critical labels
+      assert issues_result.urgent == 2
+
+      # Verify PR counting logic
+      assert prs_result.total == 4
+      # Only PR 2 is a draft
+      assert prs_result.drafts == 1
+      # PRs 1 and 4 need review
+      assert prs_result.needs_review == 2
+
+      # This test verifies that the counting logic in the success paths
+      # of both get_issues and get_pull_requests works correctly
+    end
+
+    test "count_by_labels function comprehensive testing" do
+      # Test the count_by_labels function directly using the test helper
+
+      # Test with various label configurations
+      test_issues = [
+        %{"labels" => [%{"name" => "bug"}, %{"name" => "critical"}]},
+        %{"labels" => [%{"name" => "enhancement"}, %{"name" => "feature"}]},
+        # Test case sensitivity
+        %{"labels" => [%{"name" => "URGENT"}, %{"name" => "HIGH"}]},
+        %{"labels" => [%{"name" => "documentation"}]},
+        %{"labels" => []},
+        # Test nil labels
+        %{"labels" => nil},
+        # Test partial matches
+        %{"labels" => [%{"name" => "Bug-Fix"}, %{"name" => "Error-Handling"}]},
+        %{"labels" => [%{"name" => "improvement"}, %{"name" => "request"}]}
+      ]
+
+      # Test bug labels
+      bug_count = GitHub.test_count_by_labels(test_issues, ~w[bug error critical regression])
+      # Issues with "bug"/"critical" and "Bug-Fix"/"Error-Handling"
+      assert bug_count == 2
+
+      # Test enhancement labels
+      enhancement_count =
+        GitHub.test_count_by_labels(test_issues, ~w[enhancement feature improvement request])
+
+      # Issues with "enhancement"/"feature", and "improvement"/"request"
+      assert enhancement_count == 2
+
+      # Test urgent labels
+      urgent_count = GitHub.test_count_by_labels(test_issues, ~w[critical urgent high])
+      # Issues with "critical" and "URGENT"/"HIGH"
+      assert urgent_count == 2
+
+      # Test with empty target labels
+      empty_count = GitHub.test_count_by_labels(test_issues, [])
+      assert empty_count == 0
+
+      # Test with empty issues
+      empty_issues_count = GitHub.test_count_by_labels([], ~w[bug])
+      assert empty_issues_count == 0
+    end
+  end
+
+  describe "mock gh CLI for success paths" do
+    setup do
+      # Enable mock mode for gh CLI
+      System.put_env("MOCK_GH_CLI", "true")
+
+      on_exit(fn ->
+        System.delete_env("MOCK_GH_CLI")
+        System.delete_env("MOCK_INVALID_JSON")
+      end)
+    end
+
+    test "get_issues with successful gh command" do
+      # This will use the mock response
+      result = GitHub.get_issues("test", "repo")
+
+      assert result.total == 3
+      # Issue #1 has "bug" label
+      assert result.bugs == 1
+      # Issue #2 has "enhancement" label
+      assert result.enhancements == 1
+      # Issues #1 and #3 have "critical" or "urgent" labels
+      assert result.urgent == 2
+    end
+
+    test "get_pull_requests with successful gh command" do
+      # This will use the mock response
+      result = GitHub.get_pull_requests("test", "repo")
+
+      assert result.total == 3
+      # PR #11 is a draft
+      assert result.drafts == 1
+      # PR #10 needs review
+      assert result.needs_review == 1
+    end
+
+    test "gh_api_call with invalid JSON response" do
+      System.put_env("MOCK_INVALID_JSON", "true")
+
+      # This will trigger the invalid JSON path
+      result1 = GitHub.get_issues("test", "repo")
+      result2 = GitHub.get_pull_requests("test", "repo")
+
+      # Should return default values when JSON parsing fails
+      assert result1.total == 0
+      assert result2.total == 0
+    end
+
+    test "fetch_github_info uses mock data in test" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "mock_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      System.cmd("git", ["remote", "add", "origin", "https://github.com/test/repo.git"],
+        cd: test_repo
+      )
+
+      try do
+        repo = %Repository{path: test_repo, name: "test"}
+        result = GitHub.fetch_github_info(repo)
+
+        # Should have mock data
+        assert result.issues.total == 3
+        assert result.pull_requests.total == 3
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "parse_github_url edge cases" do
+    test "parse_github_url handles malformed GitHub URLs" do
+      # Test through get_github_remote to cover the error path in parse_github_url
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "malformed_url_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      # Add a GitHub URL that won't match the regex pattern
+      System.cmd("git", ["remote", "add", "origin", "https://github.com/invalid-url-format"],
+        cd: test_repo
+      )
+
+      try do
+        repo = %Repository{path: test_repo}
+        result = GitHub.get_github_remote(repo)
+        # This covers the _ -> :error path in parse_github_url
+        assert result == :error
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "comprehensive GitHub integration" do
+    test "handles various URL formats" do
+      url_formats = [
+        "https://github.com/owner/repo.git",
+        "https://github.com/owner/repo",
+        "git@github.com:owner/repo.git",
+        "git@github.com:owner/repo"
+      ]
+
+      for url <- url_formats do
+        temp_dir = System.tmp_dir!()
+        test_repo = Path.join(temp_dir, "url_test_#{:rand.uniform(10000)}")
+        File.mkdir_p!(test_repo)
+
+        System.cmd("git", ["init"], cd: test_repo)
+        System.cmd("git", ["remote", "add", "origin", url], cd: test_repo)
+
+        try do
+          repo = %Repository{path: test_repo}
+          result = GitHub.get_github_remote(repo)
+          assert result == {:ok, {"owner", "repo"}}
+        after
+          File.rm_rf!(test_repo)
+        end
+      end
+    end
+
+    test "handles edge cases and malformed URLs" do
+      malformed_urls = [
+        "https://gitlab.com/owner/repo.git",
+        "https://bitbucket.org/owner/repo.git",
+        "invalid-url",
+        ""
+      ]
+
+      for url <- malformed_urls do
+        temp_dir = System.tmp_dir!()
+        test_repo = Path.join(temp_dir, "malformed_#{:rand.uniform(10000)}")
+        File.mkdir_p!(test_repo)
+
+        System.cmd("git", ["init"], cd: test_repo)
+        System.cmd("git", ["remote", "add", "origin", url], cd: test_repo)
+
+        try do
+          repo = %Repository{path: test_repo}
+          result = GitHub.get_github_remote(repo)
+          assert result == :error
+        after
+          File.rm_rf!(test_repo)
+        end
+      end
+    end
+
+    test "concurrent GitHub operations" do
+      temp_dir = System.tmp_dir!()
+
+      repos =
+        for i <- 1..5 do
+          test_repo = Path.join(temp_dir, "concurrent_#{i}_#{:rand.uniform(10000)}")
+          File.mkdir_p!(test_repo)
+          System.cmd("git", ["init"], cd: test_repo)
+
+          System.cmd(
+            "git",
+            ["remote", "add", "origin", "https://github.com/owner#{i}/repo#{i}.git"],
+            cd: test_repo
+          )
+
+          %Repository{path: test_repo}
+        end
+
+      try do
+        tasks =
+          for repo <- repos do
+            Task.async(fn ->
+              {
+                GitHub.get_github_remote(repo),
+                GitHub.get_pull_requests("test", "repo"),
+                GitHub.get_issues("test", "repo")
+              }
+            end)
+          end
+
+        results = Task.await_many(tasks, 5000)
+
+        for {remote_result, pr_result, issues_result} <- results do
+          assert is_tuple(remote_result) or remote_result == :error
+          assert is_map(pr_result)
+          assert is_map(issues_result)
+        end
+      after
+        for repo <- repos do
+          File.rm_rf!(repo.path)
+        end
+      end
+    end
+
+    test "concurrent operations with timeout handling" do
+      temp_dir = System.tmp_dir!()
+
+      # Create repositories with different remote configurations
+      repo_configs = [
+        {"no_remote", nil},
+        {"github_repo", "https://github.com/test1/repo1.git"},
+        {"github_ssh", "git@github.com:test2/repo2.git"},
+        {"non_github", "https://gitlab.com/test3/repo3.git"}
+      ]
+
+      repos =
+        for {name, remote} <- repo_configs do
+          repo_path = Path.join(temp_dir, "#{name}_#{:rand.uniform(10000)}")
+          File.mkdir_p!(repo_path)
+          System.cmd("git", ["init"], cd: repo_path)
+
+          if remote do
+            System.cmd("git", ["remote", "add", "origin", remote], cd: repo_path)
+          end
+
+          %Repository{path: repo_path, name: name}
+        end
+
+      try do
+        # Test concurrent GitHub operations
+        tasks =
+          for repo <- repos do
+            Task.async(fn ->
+              {
+                GitHub.get_github_remote(repo),
+                GitHub.fetch_github_info(repo)
+              }
+            end)
+          end
+
+        results = Task.await_many(tasks, 10_000)
+
+        for {remote_result, fetch_result} <- results do
+          assert is_tuple(remote_result) or remote_result == :error
+          assert is_struct(fetch_result, Repository)
+          assert is_map(fetch_result.issues)
+          assert is_map(fetch_result.pull_requests)
+        end
+      after
+        for repo <- repos do
+          File.rm_rf!(repo.path)
+        end
+      end
+    end
+
+    test "edge cases and error recovery" do
+      # Test with extreme input values
+      extreme_cases = [
+        {String.duplicate("a", 1000), "repo"},
+        {"owner", String.duplicate("b", 1000)},
+        {"owner-with-dashes", "repo_with_underscores"},
+        {"owner.dots", "repo.dots"},
+        {"123numeric", "456numeric"}
+      ]
+
+      for {owner, repo} <- extreme_cases do
+        # These should handle gracefully
+        issues = GitHub.get_issues(owner, repo)
+        prs = GitHub.get_pull_requests(owner, repo)
+
+        assert is_map(issues)
+        assert is_map(prs)
+
+        # Should have default structure even on error
+        assert Map.has_key?(issues, :total)
+        assert Map.has_key?(prs, :total)
+      end
+    end
+  end
+end

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -1,0 +1,462 @@
+defmodule EcosystemManager.RepositoryTest do
+  use ExUnit.Case
+  doctest EcosystemManager.Repository
+
+  alias EcosystemManager.Repository
+
+  describe "new function" do
+    test "creates repository struct for current directory" do
+      repo = Repository.new(".", "/test/path")
+      assert repo.name == "."
+      assert repo.path == "/test/path"
+      assert repo.display_name == "latex-ecosystem"
+      assert repo.status == :ok
+    end
+
+    test "creates repository struct for named directory" do
+      repo = Repository.new("test-repo", "/base/path")
+      assert repo.name == "test-repo"
+      assert repo.path == "/base/path/test-repo"
+      assert repo.display_name == "test-repo"
+      assert repo.status == :ok
+    end
+  end
+
+  describe "exists? function" do
+    test "identifies existing git repositories" do
+      temp_dir = System.tmp_dir!()
+      git_repo = Path.join(temp_dir, "git_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(git_repo)
+      System.cmd("git", ["init"], cd: git_repo)
+
+      try do
+        repo = Repository.new("test", git_repo)
+        repo = %{repo | path: git_repo}
+        assert Repository.exists?(repo) == true
+      after
+        File.rm_rf!(git_repo)
+      end
+    end
+
+    test "rejects non-git directories" do
+      temp_dir = System.tmp_dir!()
+      non_git = Path.join(temp_dir, "non_git_#{:rand.uniform(10000)}")
+      File.mkdir_p!(non_git)
+
+      try do
+        repo = Repository.new("test", non_git)
+        repo = %{repo | path: non_git}
+        assert Repository.exists?(repo) == false
+      after
+        File.rm_rf!(non_git)
+      end
+    end
+
+    test "handles non-existent paths" do
+      repo = Repository.new("test", "/non/existent/path")
+      repo = %{repo | path: "/non/existent/path"}
+      assert Repository.exists?(repo) == false
+    end
+  end
+
+  describe "git operations" do
+    test "gets branch for repository" do
+      temp_dir = System.tmp_dir!()
+      git_repo = Path.join(temp_dir, "branch_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(git_repo)
+      System.cmd("git", ["init"], cd: git_repo)
+      System.cmd("git", ["config", "user.email", "test@example.com"], cd: git_repo)
+      System.cmd("git", ["config", "user.name", "Test User"], cd: git_repo)
+
+      # Create initial commit
+      test_file = Path.join(git_repo, "README.md")
+      File.write!(test_file, "# Test")
+      System.cmd("git", ["add", "."], cd: git_repo)
+      System.cmd("git", ["commit", "-m", "Initial commit"], cd: git_repo)
+
+      try do
+        repo = Repository.new("test", git_repo)
+        repo = %{repo | path: git_repo}
+        branch = Repository.get_branch(repo)
+        assert is_binary(branch) or branch == nil
+      after
+        File.rm_rf!(git_repo)
+      end
+    end
+
+    test "gets changes count" do
+      temp_dir = System.tmp_dir!()
+      dirty_repo = Path.join(temp_dir, "changes_#{:rand.uniform(10000)}")
+      File.mkdir_p!(dirty_repo)
+      System.cmd("git", ["init"], cd: dirty_repo)
+
+      # Add an untracked file
+      untracked_file = Path.join(dirty_repo, "untracked.txt")
+      File.write!(untracked_file, "untracked content")
+
+      try do
+        repo = Repository.new("test", dirty_repo)
+        repo = %{repo | path: dirty_repo}
+        changes = Repository.get_changes(repo)
+        assert is_integer(changes) or changes == :missing
+        if is_integer(changes), do: assert(changes > 0)
+      after
+        File.rm_rf!(dirty_repo)
+      end
+    end
+
+    test "gets last commit" do
+      temp_dir = System.tmp_dir!()
+      commit_repo = Path.join(temp_dir, "commit_#{:rand.uniform(10000)}")
+      File.mkdir_p!(commit_repo)
+      System.cmd("git", ["init"], cd: commit_repo)
+      System.cmd("git", ["config", "user.email", "test@example.com"], cd: commit_repo)
+      System.cmd("git", ["config", "user.name", "Test User"], cd: commit_repo)
+
+      # Create initial commit
+      test_file = Path.join(commit_repo, "README.md")
+      File.write!(test_file, "# Test")
+      System.cmd("git", ["add", "."], cd: commit_repo)
+      System.cmd("git", ["commit", "-m", "Initial commit"], cd: commit_repo)
+
+      try do
+        repo = Repository.new("test", commit_repo)
+        repo = %{repo | path: commit_repo}
+        commit = Repository.get_last_commit(repo)
+        assert is_binary(commit) or commit == nil
+      after
+        File.rm_rf!(commit_repo)
+      end
+    end
+
+    test "fetches complete git info" do
+      temp_dir = System.tmp_dir!()
+      full_repo = Path.join(temp_dir, "full_#{:rand.uniform(10000)}")
+      File.mkdir_p!(full_repo)
+      System.cmd("git", ["init"], cd: full_repo)
+      System.cmd("git", ["config", "user.email", "test@example.com"], cd: full_repo)
+      System.cmd("git", ["config", "user.name", "Test User"], cd: full_repo)
+
+      # Create initial commit
+      test_file = Path.join(full_repo, "README.md")
+      File.write!(test_file, "# Test")
+      System.cmd("git", ["add", "."], cd: full_repo)
+      System.cmd("git", ["commit", "-m", "Initial commit"], cd: full_repo)
+
+      try do
+        repo = Repository.new("test", full_repo)
+        repo = %{repo | path: full_repo}
+        updated_repo = Repository.fetch_git_info(repo)
+
+        assert updated_repo.name == "test"
+        assert is_binary(updated_repo.branch) or updated_repo.branch == nil
+        assert is_integer(updated_repo.changes) or updated_repo.changes == :missing
+        assert is_binary(updated_repo.last_commit) or updated_repo.last_commit == nil
+      after
+        File.rm_rf!(full_repo)
+      end
+    end
+
+    test "handles missing repository" do
+      repo = Repository.new("missing", "/non/existent")
+      repo = %{repo | path: "/non/existent"}
+      updated_repo = Repository.fetch_git_info(repo)
+
+      assert updated_repo.status == :missing
+      assert updated_repo.changes == :missing
+    end
+  end
+
+  describe "all_repositories function" do
+    test "returns list of known repositories" do
+      repos = Repository.all_repositories()
+      assert is_list(repos)
+      assert length(repos) > 0
+      assert "." in repos
+      assert "latex-environment" in repos
+      assert "sotsuron-template" in repos
+    end
+  end
+
+  describe "display_name function coverage" do
+    test "get_display_name through new function" do
+      # Test current directory special case
+      current_repo = Repository.new(".", "/test/path")
+      assert current_repo.display_name == "latex-ecosystem"
+
+      # Test regular repository names
+      regular_names = [
+        "sotsuron-template",
+        "latex-environment",
+        "thesis-management-tools",
+        "ai-reviewer",
+        "custom-repo-name"
+      ]
+
+      for name <- regular_names do
+        repo = Repository.new(name, "/base/path")
+        assert repo.display_name == name
+      end
+    end
+  end
+
+  describe "error handling and edge cases" do
+    test "git operations with invalid repositories" do
+      # Test with completely invalid path
+      invalid_repo = Repository.new("invalid", "/definitely/not/a/real/path")
+      invalid_repo = %{invalid_repo | path: "/definitely/not/a/real/path"}
+
+      # These should handle gracefully
+      branch = Repository.get_branch(invalid_repo)
+      assert branch == nil
+
+      changes = Repository.get_changes(invalid_repo)
+      assert changes == :missing
+
+      commit = Repository.get_last_commit(invalid_repo)
+      assert commit == nil
+
+      # fetch_git_info should handle missing repositories
+      updated_repo = Repository.fetch_git_info(invalid_repo)
+      assert updated_repo.status == :missing
+      assert updated_repo.changes == :missing
+    end
+
+    test "git operations with corrupted repositories" do
+      temp_dir = System.tmp_dir!()
+      corrupted_repo = Path.join(temp_dir, "corrupted_#{:rand.uniform(10000)}")
+      File.mkdir_p!(corrupted_repo)
+
+      # Create .git directory but leave it empty (corrupted)
+      git_dir = Path.join(corrupted_repo, ".git")
+      File.mkdir_p!(git_dir)
+
+      try do
+        repo = Repository.new("corrupted", corrupted_repo)
+        repo = %{repo | path: corrupted_repo}
+
+        # exists? should return true (directory and .git exist)
+        assert Repository.exists?(repo) == true
+
+        # But git operations should fail gracefully
+        branch = Repository.get_branch(repo)
+        assert branch == nil
+
+        changes = Repository.get_changes(repo)
+        assert changes == :missing
+
+        commit = Repository.get_last_commit(repo)
+        assert commit == nil
+
+        # fetch_git_info should still work but return missing data
+        updated_repo = Repository.fetch_git_info(repo)
+        assert updated_repo.branch == nil
+        assert updated_repo.changes == :missing
+        assert updated_repo.last_commit == nil
+      after
+        File.rm_rf!(corrupted_repo)
+      end
+    end
+
+    test "all_repositories function consistency" do
+      repos1 = Repository.all_repositories()
+      repos2 = Repository.all_repositories()
+
+      # Should be consistent across calls
+      assert repos1 == repos2
+
+      # Should contain expected core repositories
+      expected_repos = [
+        ".",
+        "texlive-ja-textlint",
+        "latex-environment",
+        "sotsuron-template",
+        "thesis-management-tools"
+      ]
+
+      for expected <- expected_repos do
+        assert expected in repos1
+      end
+
+      # Should be a reasonable number of repositories
+      assert length(repos1) > 5
+      assert length(repos1) < 20
+    end
+  end
+
+  describe "comprehensive repository operations" do
+    test "full repository workflow" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "workflow_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+      System.cmd("git", ["config", "user.email", "test@example.com"], cd: test_repo)
+      System.cmd("git", ["config", "user.name", "Test User"], cd: test_repo)
+
+      # Create and commit files
+      readme = Path.join(test_repo, "README.md")
+      File.write!(readme, "# Workflow Test")
+      System.cmd("git", ["add", "."], cd: test_repo)
+      System.cmd("git", ["commit", "-m", "Initial commit"], cd: test_repo)
+
+      # Add uncommitted changes
+      new_file = Path.join(test_repo, "new.txt")
+      File.write!(new_file, "new content")
+
+      try do
+        # Test full workflow
+        repo = Repository.new("workflow", test_repo)
+        repo = %{repo | path: test_repo}
+
+        # Check existence
+        assert Repository.exists?(repo)
+
+        # Fetch git info
+        updated_repo = Repository.fetch_git_info(repo)
+
+        assert updated_repo.status == :ok
+        assert is_binary(updated_repo.branch)
+        assert is_integer(updated_repo.changes) and updated_repo.changes > 0
+        assert is_binary(updated_repo.last_commit)
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "concurrent operations" do
+      temp_dir = System.tmp_dir!()
+
+      # Create multiple test repositories
+      repos =
+        for i <- 1..5 do
+          repo_path = Path.join(temp_dir, "concurrent_#{i}_#{:rand.uniform(10000)}")
+          File.mkdir_p!(repo_path)
+          System.cmd("git", ["init"], cd: repo_path)
+
+          repo = Repository.new("test#{i}", repo_path)
+          %{repo | path: repo_path}
+        end
+
+      try do
+        # Test concurrent operations
+        tasks =
+          for repo <- repos do
+            Task.async(fn ->
+              Repository.exists?(repo) &&
+                Repository.fetch_git_info(repo)
+            end)
+          end
+
+        results = Task.await_many(tasks, 5000)
+
+        for result <- results do
+          assert result != false
+        end
+      after
+        for repo <- repos do
+          File.rm_rf!(repo.path)
+        end
+      end
+    end
+
+    test "stress testing with many repositories" do
+      temp_dir = System.tmp_dir!()
+      stress_base = Path.join(temp_dir, "stress_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(stress_base)
+
+      # Create many repositories for stress testing
+      repo_count = 20
+
+      repos =
+        for i <- 1..repo_count do
+          repo_path = Path.join(stress_base, "repo#{i}")
+          File.mkdir_p!(repo_path)
+          System.cmd("git", ["init"], cd: repo_path)
+          System.cmd("git", ["config", "user.email", "test@example.com"], cd: repo_path)
+          System.cmd("git", ["config", "user.name", "Test User"], cd: repo_path)
+
+          # Add some files to some repositories
+          if rem(i, 3) == 0 do
+            File.write!(Path.join(repo_path, "README.md"), "# Repository #{i}")
+            System.cmd("git", ["add", "."], cd: repo_path)
+            System.cmd("git", ["commit", "-m", "Initial commit"], cd: repo_path)
+          end
+
+          # Add uncommitted changes to some
+          if rem(i, 4) == 0 do
+            File.write!(Path.join(repo_path, "uncommitted.txt"), "changes")
+          end
+
+          Repository.new("repo#{i}", repo_path)
+          |> Map.put(:path, repo_path)
+        end
+
+      try do
+        # Test batch operations
+        {time_micros, results} =
+          :timer.tc(fn ->
+            for repo <- repos do
+              Repository.fetch_git_info(repo)
+            end
+          end)
+
+        # Should complete in reasonable time
+        # Less than 5 seconds
+        assert time_micros < 5_000_000
+        assert length(results) == repo_count
+
+        # All results should be valid
+        for result <- results do
+          assert is_struct(result, Repository)
+          assert result.status in [:ok, :missing]
+          assert is_binary(result.name)
+        end
+
+        # Test concurrent operations
+        concurrent_tasks =
+          for repo <- Enum.take(repos, 10) do
+            Task.async(fn ->
+              Repository.fetch_git_info(repo)
+            end)
+          end
+
+        concurrent_results = Task.await_many(concurrent_tasks, 10_000)
+
+        for result <- concurrent_results do
+          assert is_struct(result, Repository)
+        end
+      after
+        File.rm_rf!(stress_base)
+      end
+    end
+
+    test "repository struct field validation" do
+      # Test that new repositories have all expected fields
+      repo = Repository.new("test", "/path")
+
+      # Check all struct fields are present
+      assert Map.has_key?(repo, :name)
+      assert Map.has_key?(repo, :path)
+      assert Map.has_key?(repo, :display_name)
+      assert Map.has_key?(repo, :branch)
+      assert Map.has_key?(repo, :changes)
+      assert Map.has_key?(repo, :last_commit)
+      assert Map.has_key?(repo, :issues)
+      assert Map.has_key?(repo, :pull_requests)
+      assert Map.has_key?(repo, :status)
+
+      # Check initial values
+      assert repo.name == "test"
+      assert repo.path == "/path/test"
+      assert repo.display_name == "test"
+      assert repo.status == :ok
+
+      # Check nil/unset fields
+      assert repo.branch == nil
+      assert repo.changes == nil
+      assert repo.last_commit == nil
+      assert repo.issues == nil
+      assert repo.pull_requests == nil
+    end
+  end
+end

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -278,9 +278,10 @@ defmodule EcosystemManager.RepositoryTest do
         assert expected in repos1
       end
 
-      # Should be a reasonable number of repositories
+      # Should be a reasonable number of repositories (generous upper bound
+      # so the test does not break as the ecosystem grows)
       assert length(repos1) > 5
-      assert length(repos1) < 20
+      assert length(repos1) < 50
     end
   end
 

--- a/ecosystem_manager/test/status_test.exs
+++ b/ecosystem_manager/test/status_test.exs
@@ -509,11 +509,13 @@ defmodule EcosystemManager.StatusTest do
     test "performance with large number of options" do
       base_path = File.cwd!()
 
-      # Test with various option combinations
+      # Test with various option combinations. include_github stays false
+      # so the test never depends on the network or the gh CLI; concurrency
+      # variation is what this test is about.
       option_combinations = [
         [include_github: false],
-        [include_github: true, max_concurrency: 1],
-        [include_github: true, max_concurrency: 4],
+        [include_github: false, max_concurrency: 1],
+        [include_github: false, max_concurrency: 4],
         [include_github: false, max_concurrency: 8]
       ]
 

--- a/ecosystem_manager/test/status_test.exs
+++ b/ecosystem_manager/test/status_test.exs
@@ -179,65 +179,25 @@ defmodule EcosystemManager.StatusTest do
     end
 
     test "sorts repositories by last commit time when time_sort option is provided" do
-      temp_dir = System.tmp_dir!()
-      test_ecosystem = Path.join(temp_dir, "time_sort_test_#{:rand.uniform(10000)}")
-      File.mkdir_p!(test_ecosystem)
-
-      # Create test repositories sequentially with delays
-      repo_configs = [
-        # created first
-        {"oldest_repo", 0},
-        # 1 second delay
-        {"middle_repo", 1000},
-        # 2 seconds delay
-        {"newest_repo", 2000}
+      # Build repository structs with explicit timestamps instead of real
+      # git repos with sleeps: the sort only reads last_commit_timestamp,
+      # and this keeps the test fast and deterministic
+      test_repos = [
+        %Repository{name: "oldest_repo", last_commit_timestamp: 1_000},
+        %Repository{name: "newest_repo", last_commit_timestamp: 3_000},
+        %Repository{name: "middle_repo", last_commit_timestamp: 2_000},
+        %Repository{name: "no_commit_repo", last_commit_timestamp: nil}
       ]
 
-      test_repos =
-        for {name, delay} <- repo_configs do
-          repo_path = Path.join(test_ecosystem, name)
-          File.mkdir_p!(repo_path)
-          System.cmd("git", ["init"], cd: repo_path)
-          System.cmd("git", ["config", "user.email", "test@example.com"], cd: repo_path)
-          System.cmd("git", ["config", "user.name", "Test User"], cd: repo_path)
+      sorted_repos = Status.sort_repositories_by_time(test_repos)
 
-          # Sleep to create time difference
-          if delay > 0, do: Process.sleep(delay)
-
-          # Create initial commit
-          File.write!(Path.join(repo_path, "README.md"), "# #{name}")
-          System.cmd("git", ["add", "README.md"], cd: repo_path)
-          System.cmd("git", ["commit", "-m", "Initial commit for #{name}"], cd: repo_path)
-
-          Repository.new(name, test_ecosystem) |> Repository.fetch_git_info()
-        end
-
-      try do
-        # Test sorting by last commit time (newest first)
-        sorted_repos = Status.sort_repositories_by_time(test_repos)
-
-        # Should be sorted by last_commit timestamp (newest first)
-        assert length(sorted_repos) == 3
-
-        # Get timestamps to verify sorting
-        timestamps =
-          Enum.map(sorted_repos, fn repo ->
-            {repo.name, repo.last_commit_timestamp || 0}
-          end)
-
-        # Should be sorted in descending order (newest first)
-        sorted_timestamps = Enum.map(timestamps, fn {_, ts} -> ts end)
-        assert sorted_timestamps == Enum.sort(sorted_timestamps, :desc)
-
-        # Verify sort order: newest first, oldest last
-        repo_names = Enum.map(sorted_repos, & &1.name)
-        # newest_repo was created last
-        assert List.first(repo_names) == "newest_repo"
-        # oldest_repo was created first
-        assert List.last(repo_names) == "oldest_repo"
-      after
-        File.rm_rf!(test_ecosystem)
-      end
+      # Newest first; repos without commits (nil timestamp) go last
+      assert Enum.map(sorted_repos, & &1.name) == [
+               "newest_repo",
+               "middle_repo",
+               "oldest_repo",
+               "no_commit_repo"
+             ]
     end
 
     test "truncate_string function coverage" do

--- a/ecosystem_manager/test/status_test.exs
+++ b/ecosystem_manager/test/status_test.exs
@@ -1,0 +1,573 @@
+defmodule EcosystemManager.StatusTest do
+  use ExUnit.Case
+  doctest EcosystemManager.Status
+
+  alias EcosystemManager.{Repository, Status}
+
+  describe "get_all_status function" do
+    test "gets status for current directory" do
+      base_path = File.cwd!()
+      repos = Status.get_all_status(base_path, include_github: false)
+
+      assert is_list(repos)
+      assert length(repos) > 0
+
+      # Each repo should have required fields
+      for repo <- repos do
+        assert is_binary(repo.name)
+        assert is_binary(repo.path)
+        assert repo.status in [:ok, :missing]
+        assert is_integer(repo.changes) or repo.changes == :missing
+      end
+    end
+
+    test "handles non-existent directory" do
+      repos = Status.get_all_status("/non/existent/path", [])
+      # Should still return repository structs, but with :missing status
+      assert is_list(repos)
+      assert length(repos) > 0
+
+      for repo <- repos do
+        assert repo.status == :missing
+        assert repo.changes == :missing
+      end
+    end
+
+    test "includes GitHub data when requested" do
+      base_path = File.cwd!()
+      repos = Status.get_all_status(base_path, include_github: true, max_concurrency: 2)
+
+      assert is_list(repos)
+
+      # Should have GitHub fields when include_github is true
+      for repo <- repos do
+        assert Map.has_key?(repo, :pull_requests)
+        assert Map.has_key?(repo, :issues)
+        assert is_map(repo.pull_requests)
+        assert is_map(repo.issues)
+      end
+    end
+
+    test "respects max_concurrency option" do
+      base_path = File.cwd!()
+
+      # Test with different concurrency levels
+      for concurrency <- [1, 2, 4, 8] do
+        repos =
+          Status.get_all_status(base_path, include_github: false, max_concurrency: concurrency)
+
+        assert is_list(repos)
+      end
+    end
+  end
+
+  describe "get_repository_status function" do
+    test "gets status for existing repository" do
+      base_path = File.cwd!()
+
+      # Find a repository in the current directory
+      all_repos = Status.get_all_status(base_path, include_github: false)
+
+      if length(all_repos) > 0 do
+        first_repo = hd(all_repos)
+
+        result = Status.get_repository_status(first_repo.name, base_path, include_github: false)
+
+        assert is_map(result)
+        assert result.name == first_repo.name
+        assert result.status in [:ok, :missing]
+        assert is_integer(result.changes) or result.changes == :missing
+      end
+    end
+
+    test "returns repository with missing status for non-existent repository" do
+      base_path = File.cwd!()
+      result = Status.get_repository_status("non-existent-repo", base_path, [])
+      assert result.status == :missing
+      assert result.changes == :missing
+    end
+  end
+
+  describe "format_status function" do
+    test "formats status in compact mode" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "format_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = %Repository{path: test_repo, name: "format_test"}
+        repo_with_status = Repository.fetch_git_info(repo)
+
+        formatted = Status.format_status([repo_with_status], format: :compact)
+
+        assert is_binary(formatted)
+        # Check that formatting works and contains expected structure
+        assert String.length(formatted) > 0
+        # The repository name might be truncated or processed differently
+        assert String.contains?(formatted, "main") or String.contains?(formatted, "clean")
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "formats status in long mode" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "long_format_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = %Repository{path: test_repo, name: "long_format"}
+        repo_with_status = Repository.fetch_git_info(repo)
+
+        formatted = Status.format_status([repo_with_status], format: :long)
+
+        assert is_binary(formatted)
+        # Check that formatting works and contains expected structure
+        assert String.length(formatted) > 0
+        # The repository name might be truncated or processed differently
+        assert String.contains?(formatted, "main") or String.contains?(formatted, "clean")
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "applies filters correctly" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "filter_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = %Repository{path: test_repo, name: "filter_test"}
+
+        repo_with_status =
+          repo
+          |> Repository.fetch_git_info()
+          |> Map.put(:pull_requests, %{total: 0, drafts: 0, needs_review: 0})
+          |> Map.put(:issues, %{total: 0, bugs: 0, enhancements: 0, urgent: 0})
+
+        # Test different filter combinations
+        filters = [
+          [],
+          [urgent_issues_only: true],
+          [with_prs_only: true],
+          [needs_review_only: true]
+        ]
+
+        for filter_list <- filters do
+          formatted =
+            Status.format_status([repo_with_status], format: :compact, filters: filter_list)
+
+          assert is_binary(formatted)
+        end
+
+        # Test time_sort option
+        formatted_time_sorted =
+          Status.format_status([repo_with_status], format: :compact, time_sort: true)
+
+        assert is_binary(formatted_time_sorted)
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "handles empty repository list" do
+      formatted = Status.format_status([], format: :compact)
+      assert is_binary(formatted)
+    end
+
+    test "sorts repositories by last commit time when time_sort option is provided" do
+      temp_dir = System.tmp_dir!()
+      test_ecosystem = Path.join(temp_dir, "time_sort_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_ecosystem)
+
+      # Create test repositories sequentially with delays
+      repo_configs = [
+        # created first
+        {"oldest_repo", 0},
+        # 1 second delay
+        {"middle_repo", 1000},
+        # 2 seconds delay
+        {"newest_repo", 2000}
+      ]
+
+      test_repos =
+        for {name, delay} <- repo_configs do
+          repo_path = Path.join(test_ecosystem, name)
+          File.mkdir_p!(repo_path)
+          System.cmd("git", ["init"], cd: repo_path)
+          System.cmd("git", ["config", "user.email", "test@example.com"], cd: repo_path)
+          System.cmd("git", ["config", "user.name", "Test User"], cd: repo_path)
+
+          # Sleep to create time difference
+          if delay > 0, do: Process.sleep(delay)
+
+          # Create initial commit
+          File.write!(Path.join(repo_path, "README.md"), "# #{name}")
+          System.cmd("git", ["add", "README.md"], cd: repo_path)
+          System.cmd("git", ["commit", "-m", "Initial commit for #{name}"], cd: repo_path)
+
+          Repository.new(name, test_ecosystem) |> Repository.fetch_git_info()
+        end
+
+      try do
+        # Test sorting by last commit time (newest first)
+        sorted_repos = Status.sort_repositories_by_time(test_repos)
+
+        # Should be sorted by last_commit timestamp (newest first)
+        assert length(sorted_repos) == 3
+
+        # Get timestamps to verify sorting
+        timestamps =
+          Enum.map(sorted_repos, fn repo ->
+            {repo.name, repo.last_commit_timestamp || 0}
+          end)
+
+        # Should be sorted in descending order (newest first)
+        sorted_timestamps = Enum.map(timestamps, fn {_, ts} -> ts end)
+        assert sorted_timestamps == Enum.sort(sorted_timestamps, :desc)
+
+        # Verify sort order: newest first, oldest last
+        repo_names = Enum.map(sorted_repos, & &1.name)
+        # newest_repo was created last
+        assert List.first(repo_names) == "newest_repo"
+        # oldest_repo was created first
+        assert List.last(repo_names) == "oldest_repo"
+      after
+        File.rm_rf!(test_ecosystem)
+      end
+    end
+
+    test "truncate_string function coverage" do
+      # Test through format_status which uses truncate_string internally
+      temp_dir = System.tmp_dir!()
+
+      long_name_repo =
+        Path.join(
+          temp_dir,
+          "very_long_repository_name_that_exceeds_normal_limits_#{:rand.uniform(10000)}"
+        )
+
+      File.mkdir_p!(long_name_repo)
+      System.cmd("git", ["init"], cd: long_name_repo)
+
+      try do
+        repo =
+          Repository.new("very_long_repository_name_that_exceeds_normal_limits", long_name_repo)
+
+        repo = %{repo | path: long_name_repo}
+        repo_with_status = Repository.fetch_git_info(repo)
+
+        # Add GitHub info
+        repo_with_status =
+          repo_with_status
+          |> Map.put(:pull_requests, %{total: 0, drafts: 0, needs_review: 0})
+          |> Map.put(:issues, %{total: 0, bugs: 0, enhancements: 0, urgent: 0})
+
+        # Test both compact and long formats
+        compact_output = Status.format_status([repo_with_status], format: :compact)
+        long_output = Status.format_status([repo_with_status], format: :long)
+
+        assert is_binary(compact_output)
+        assert is_binary(long_output)
+
+        # Both outputs should be valid
+        assert String.length(compact_output) > 0
+        assert String.length(long_output) > 0
+      after
+        File.rm_rf!(long_name_repo)
+      end
+    end
+
+    test "format functions with different data structures" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "format_data_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = Repository.new("format_test", test_repo)
+        repo = %{repo | path: test_repo}
+
+        # Test with various issue/PR combinations
+        test_data_combinations = [
+          # No issues or PRs
+          {%{total: 0, bugs: 0, enhancements: 0, urgent: 0},
+           %{total: 0, drafts: 0, needs_review: 0}},
+          # Only issues
+          {%{total: 5, bugs: 2, enhancements: 2, urgent: 1},
+           %{total: 0, drafts: 0, needs_review: 0}},
+          # Only PRs
+          {%{total: 0, bugs: 0, enhancements: 0, urgent: 0},
+           %{total: 3, drafts: 1, needs_review: 2}},
+          # Both issues and PRs
+          {%{total: 10, bugs: 4, enhancements: 3, urgent: 3},
+           %{total: 5, drafts: 2, needs_review: 3}},
+          # High numbers
+          {%{total: 100, bugs: 50, enhancements: 30, urgent: 20},
+           %{total: 50, drafts: 10, needs_review: 40}}
+        ]
+
+        for {issues, prs} <- test_data_combinations do
+          repo_with_data =
+            Repository.fetch_git_info(repo)
+            |> Map.put(:issues, issues)
+            |> Map.put(:pull_requests, prs)
+
+          # Test both formats
+          compact = Status.format_status([repo_with_data], format: :compact)
+          long = Status.format_status([repo_with_data], format: :long)
+
+          assert is_binary(compact)
+          assert is_binary(long)
+
+          # Verify content contains expected numbers
+          assert String.contains?(compact, "#{issues.total}") or issues.total == 0
+          assert String.contains?(compact, "#{prs.total}") or prs.total == 0
+        end
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "private function coverage" do
+    test "apply_filters function comprehensive testing" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "filter_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        # Create test repositories with different characteristics
+        test_repos = [
+          # Repository with urgent issues
+          Repository.fetch_git_info(Repository.new("urgent_repo", test_repo))
+          |> Map.put(:issues, %{total: 5, bugs: 2, enhancements: 1, urgent: 2})
+          |> Map.put(:pull_requests, %{total: 0, drafts: 0, needs_review: 0}),
+
+          # Repository with PRs
+          Repository.fetch_git_info(Repository.new("pr_repo", test_repo))
+          |> Map.put(:issues, %{total: 0, bugs: 0, enhancements: 0, urgent: 0})
+          |> Map.put(:pull_requests, %{total: 3, drafts: 1, needs_review: 2}),
+
+          # Repository with PRs needing review
+          Repository.fetch_git_info(Repository.new("review_repo", test_repo))
+          |> Map.put(:issues, %{total: 0, bugs: 0, enhancements: 0, urgent: 0})
+          |> Map.put(:pull_requests, %{total: 5, drafts: 2, needs_review: 3}),
+
+          # Repository with no issues/PRs
+          Repository.fetch_git_info(Repository.new("clean_repo", test_repo))
+          |> Map.put(:issues, %{total: 0, bugs: 0, enhancements: 0, urgent: 0})
+          |> Map.put(:pull_requests, %{total: 0, drafts: 0, needs_review: 0})
+        ]
+
+        # Test different filter combinations
+        filter_tests = [
+          # No filters (should return all)
+          {[], 4},
+          # Urgent issues only
+          {[urgent_issues_only: true], 1},
+          # With PRs only
+          {[with_prs_only: true], 2},
+          # Needs review only
+          {[needs_review_only: true], 1},
+          # Multiple filters (should use AND logic)
+          {[urgent_issues_only: true, with_prs_only: true], 0},
+          {[with_prs_only: true, needs_review_only: true], 1}
+        ]
+
+        for {filters, expected_count} <- filter_tests do
+          formatted = Status.format_status(test_repos, format: :compact, filters: filters)
+          assert is_binary(formatted)
+
+          # For non-empty results, should contain repository information
+          if expected_count > 0 do
+            assert String.length(formatted) > 0
+          end
+        end
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "fetch_repository_info with different include_github settings" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "fetch_info_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        base_repo = Repository.new("test", test_repo)
+        _base_repo = %{base_repo | path: test_repo}
+
+        # Test with include_github: true (should try to fetch GitHub info)
+        result_with_github = Status.get_repository_status("test", test_repo, include_github: true)
+        assert is_map(result_with_github.issues)
+        assert is_map(result_with_github.pull_requests)
+
+        # Test with include_github: false (should use defaults)
+        result_without_github =
+          Status.get_repository_status("test", test_repo, include_github: false)
+
+        assert result_without_github.issues.total == 0
+        assert result_without_github.pull_requests.total == 0
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+
+    test "sprintf function coverage through format functions" do
+      temp_dir = System.tmp_dir!()
+      test_repo = Path.join(temp_dir, "sprintf_test_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_repo)
+      System.cmd("git", ["init"], cd: test_repo)
+
+      try do
+        repo = Repository.new("sprintf_test", test_repo)
+        repo = %{repo | path: test_repo}
+
+        repo_with_data =
+          Repository.fetch_git_info(repo)
+          |> Map.put(:issues, %{total: 42, bugs: 10, enhancements: 20, urgent: 12})
+          |> Map.put(:pull_requests, %{total: 15, drafts: 5, needs_review: 10})
+
+        # Test long format which uses sprintf internally
+        long_output = Status.format_status([repo_with_data], format: :long)
+
+        assert is_binary(long_output)
+        # issues total
+        assert String.contains?(long_output, "42")
+        # PRs total
+        assert String.contains?(long_output, "15")
+      after
+        File.rm_rf!(test_repo)
+      end
+    end
+  end
+
+  describe "comprehensive status operations" do
+    test "full status workflow with multiple repositories" do
+      temp_dir = System.tmp_dir!()
+      test_ecosystem = Path.join(temp_dir, "status_ecosystem_#{:rand.uniform(10000)}")
+      File.mkdir_p!(test_ecosystem)
+
+      # Create multiple test repositories
+      repo_configs = [
+        {"clean_repo", []},
+        {"dirty_repo", ["untracked.txt"]},
+        {"staged_repo", ["staged.txt"]}
+      ]
+
+      for {name, files} <- repo_configs do
+        repo_path = Path.join(test_ecosystem, name)
+        File.mkdir_p!(repo_path)
+        System.cmd("git", ["init"], cd: repo_path)
+        System.cmd("git", ["config", "user.email", "test@example.com"], cd: repo_path)
+        System.cmd("git", ["config", "user.name", "Test User"], cd: repo_path)
+
+        # Create initial commit
+        File.write!(Path.join(repo_path, "README.md"), "# #{name}")
+        System.cmd("git", ["add", "README.md"], cd: repo_path)
+        System.cmd("git", ["commit", "-m", "Initial commit"], cd: repo_path)
+
+        # Add files based on configuration
+        for file <- files do
+          File.write!(Path.join(repo_path, file), "content for #{file}")
+
+          if String.contains?(file, "staged") do
+            System.cmd("git", ["add", file], cd: repo_path)
+          end
+        end
+      end
+
+      try do
+        # Test full status workflow
+        repos = Status.get_all_status(test_ecosystem, include_github: false, max_concurrency: 2)
+
+        # Verify we have repos (ecosystem repos are always included)
+        assert length(repos) >= 3
+
+        # Check if our test repos are there (they might not be found if they don't have git structure)
+        test_repo_names = ["repo1", "repo2", "repo3"]
+        test_repos = Enum.filter(repos, fn repo -> repo.name in test_repo_names end)
+        # We expect some repos to be found
+        assert length(test_repos) >= 0
+
+        # Verify each repository has proper status
+        for repo <- repos do
+          assert is_binary(repo.name)
+          assert is_binary(repo.path)
+          assert repo.status in [:ok, :missing]
+          assert is_integer(repo.changes) or repo.changes == :missing
+        end
+
+        # Test formatting
+        compact_output = Status.format_status(repos, format: :compact)
+        long_output = Status.format_status(repos, format: :long)
+
+        assert is_binary(compact_output)
+        assert is_binary(long_output)
+
+        # Both outputs should be valid
+        assert String.length(compact_output) > 0
+        assert String.length(long_output) > 0
+      after
+        File.rm_rf!(test_ecosystem)
+      end
+    end
+
+    test "concurrent status operations" do
+      base_path = File.cwd!()
+
+      # Run multiple status operations concurrently
+      tasks =
+        for _i <- 1..5 do
+          Task.async(fn ->
+            Status.get_all_status(base_path, include_github: false, max_concurrency: 2)
+          end)
+        end
+
+      results = Task.await_many(tasks, 10_000)
+
+      # All results should be valid and consistent
+      first_result = hd(results)
+
+      for result <- results do
+        assert is_list(result)
+        assert length(result) == length(first_result)
+
+        # Repository names should be consistent
+        result_names = Enum.map(result, & &1.name) |> Enum.sort()
+        first_names = Enum.map(first_result, & &1.name) |> Enum.sort()
+        assert result_names == first_names
+      end
+    end
+
+    test "performance with large number of options" do
+      base_path = File.cwd!()
+
+      # Test with various option combinations
+      option_combinations = [
+        [include_github: false],
+        [include_github: true, max_concurrency: 1],
+        [include_github: true, max_concurrency: 4],
+        [include_github: false, max_concurrency: 8]
+      ]
+
+      for opts <- option_combinations do
+        {time_micros, repos} =
+          :timer.tc(fn ->
+            Status.get_all_status(base_path, opts)
+          end)
+
+        # Should complete in reasonable time
+        # Less than 10 seconds
+        assert time_micros < 10_000_000
+        assert is_list(repos)
+      end
+    end
+  end
+end

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -47,6 +47,34 @@ defmodule EcosystemManager.UserConfigTest do
       end)
     end
 
+    test "returns error when the config directory cannot be created" do
+      # Point the config dir below a regular file so mkdir_p reliably
+      # fails with :enotdir on every platform
+      temp_dir = System.tmp_dir!()
+      blocker = Path.join(temp_dir, "blocker_#{:rand.uniform(10_000)}")
+      File.write!(blocker, "not a directory")
+
+      original = System.get_env("ECOSYSTEM_MANAGER_CONFIG_DIR")
+
+      try do
+        System.put_env("ECOSYSTEM_MANAGER_CONFIG_DIR", Path.join(blocker, "nested"))
+
+        assert {:error, message} = UserConfig.create_example_config()
+        assert message =~ "config"
+
+        assert {:error, message} = UserConfig.create_default_config("/test/workspace")
+        assert message =~ "config"
+      after
+        if original do
+          System.put_env("ECOSYSTEM_MANAGER_CONFIG_DIR", original)
+        else
+          System.delete_env("ECOSYSTEM_MANAGER_CONFIG_DIR")
+        end
+
+        File.rm(blocker)
+      end
+    end
+
     test "handles file write errors gracefully" do
       # Test error case by trying to write to a read-only directory
       # This is hard to test directly, so we'll test the structure
@@ -219,61 +247,14 @@ defmodule EcosystemManager.UserConfigTest do
   end
 
   describe "create_default_config/1" do
-    test "validates that config creation logic works" do
-      # Test the actual content generation logic without filesystem conflicts
-      workspace = "/test/workspace"
+    test "uses the default workspace placeholder when no path is given" do
+      with_temp_config_dir(fn config_dir ->
+        assert {:ok, config_path} = UserConfig.create_default_config()
+        assert config_path == Path.join(config_dir, "config.exs")
 
-      expected_content = """
-      # EcosystemManager User Configuration
-      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
-
-      import Config
-
-      # Set your LaTeX ecosystem workspace path
-      config :ecosystem_manager,
-        workspace_path: #{inspect(workspace)},
-        
-        # Optional: Custom repository list
-        # repositories: [
-        #   ".",
-        #   "texlive-ja-textlint",
-        #   "latex-environment",
-        #   "sotsuron-template"
-        # ]
-      """
-
-      # Test that the content structure is correct
-      assert String.contains?(expected_content, workspace)
-      assert String.contains?(expected_content, "import Config")
-      assert String.contains?(expected_content, "repositories:")
-    end
-
-    test "validates default workspace path logic" do
-      # Test default path logic
-      default_workspace = "~/path/to/latex-ecosystem"
-
-      expected_content = """
-      # EcosystemManager User Configuration
-      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
-
-      import Config
-
-      # Set your LaTeX ecosystem workspace path
-      config :ecosystem_manager,
-        workspace_path: #{inspect(default_workspace)},
-        
-        # Optional: Custom repository list
-        # repositories: [
-        #   ".",
-        #   "texlive-ja-textlint",
-        #   "latex-environment",
-        #   "sotsuron-template"
-        # ]
-      """
-
-      # Test that the content structure is correct
-      assert String.contains?(expected_content, default_workspace)
-      assert String.contains?(expected_content, "import Config")
+        content = File.read!(config_path)
+        assert String.contains?(content, ~s(workspace_path: "~/path/to/latex-ecosystem"))
+      end)
     end
 
     test "creates default config file when none exists" do

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -143,6 +143,25 @@ defmodule EcosystemManager.UserConfigTest do
       end)
     end
 
+    test "handles config file using build-time-only config_env/0" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        case config_env() do
+          _ -> config :ecosystem_manager, workspace_path: "/test/workspace"
+        end
+        """)
+
+        # config_env/0 is build-time only; loading must fail gracefully
+        # instead of crashing the CLI
+        assert {:error, message} = UserConfig.load()
+        assert message =~ "configuration"
+      end)
+    end
+
     test "handles config file that throws" do
       with_temp_config_dir(fn config_dir ->
         config_path = Path.join(config_dir, "config.exs")

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -20,23 +20,12 @@ defmodule EcosystemManager.UserConfigTest do
 
   describe "create_example_config/0" do
     test "creates example config file successfully" do
-      # Test in a temporary directory by temporarily overriding the config directory
-      temp_dir = System.tmp_dir!()
-      test_home = Path.join(temp_dir, "test_home_#{:rand.uniform(10_000)}")
-      test_config_dir = Path.join(test_home, ".config/ecosystem-manager")
-
-      original_home = System.get_env("HOME")
-
-      try do
-        # Override HOME environment variable
-        System.put_env("HOME", test_home)
-        File.mkdir_p!(test_config_dir)
-
-        # Call the actual function
+      with_temp_config_dir(fn config_dir ->
         result = UserConfig.create_example_config()
 
         case result do
           {:ok, example_path} ->
+            assert Path.dirname(example_path) == config_dir
             assert File.exists?(example_path)
             assert String.ends_with?(example_path, "config.example.exs")
 
@@ -49,16 +38,7 @@ defmodule EcosystemManager.UserConfigTest do
           {:error, reason} ->
             flunk("Expected success but got error: #{reason}")
         end
-      after
-        # Restore original HOME
-        if original_home do
-          System.put_env("HOME", original_home)
-        else
-          System.delete_env("HOME")
-        end
-
-        File.rm_rf!(test_home)
-      end
+      end)
     end
 
     test "handles file write errors gracefully" do
@@ -120,65 +100,81 @@ defmodule EcosystemManager.UserConfigTest do
     end
 
     test "returns :ok when config file doesn't exist" do
-      # Test with non-existent path by overriding the config path temporarily
-      # Create a module attribute override approach or test the logic directly
-      assert UserConfig.load() == :ok
+      with_temp_config_dir(fn _config_dir ->
+        assert UserConfig.load() == :ok
+      end)
     end
 
     test "loads valid config file and applies settings" do
-      # Test valid config parsing logic without creating files that could
-      # interfere with the compilation process during testing
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
 
-      # Test the structure that Config.Reader expects
-      config_content = """
-      import Config
+        File.write!(config_path, """
+        import Config
 
-      config :ecosystem_manager,
-        workspace_path: "/test/workspace",
-        repositories: ["test-repo1", "test-repo2"]
-      """
+        config :ecosystem_manager,
+          workspace_path: "/test/workspace",
+          repositories: ["test-repo1", "test-repo2"]
+        """)
 
-      # Verify the content structure is valid by testing string parsing
-      assert String.contains?(config_content, "workspace_path:")
-      assert String.contains?(config_content, "repositories:")
-      assert String.contains?(config_content, "import Config")
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspace_path) == "/test/workspace"
 
-      # The actual UserConfig.load() would use Config.Reader.read! in practice
-      # Validate test structure
-      assert :ok == :ok
+        assert Application.get_env(:ecosystem_manager, :repositories) == [
+                 "test-repo1",
+                 "test-repo2"
+               ]
+      end)
     end
 
     test "handles invalid config file gracefully" do
-      # Test error handling for invalid syntax without creating actual files
-      # that might be processed by the Elixir compiler during testing
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+        File.write!(config_path, "invalid elixir syntax {{")
 
-      invalid_syntax = "invalid elixir syntax {{"
-
-      # Test that Code.eval_string would fail as expected
-      assert_raise TokenMissingError, fn ->
-        Code.eval_string(invalid_syntax)
-      end
-
-      # The actual UserConfig.load() handles this gracefully with try/rescue
-      # Validate test structure
-      assert :ok == :ok
+        assert {:error, message} = UserConfig.load()
+        assert message =~ "configuration"
+      end)
     end
 
     test "handles config file with missing import Config" do
-      # Test that UserConfig.load() handles errors gracefully
-      # This validates the error handling structure in the load() function
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
 
-      # The load() function uses try/rescue to handle CompileError and SyntaxError
-      # We test that the error handling logic structure is correct
-      error_types = [CompileError, SyntaxError]
+        File.write!(config_path, """
+        config :ecosystem_manager, workspace_path: "/test/workspace"
+        """)
 
-      # Verify that these are the expected error types for config issues
-      assert CompileError in error_types
-      assert SyntaxError in error_types
+        assert {:error, message} = UserConfig.load()
+        assert message =~ "configuration"
+      end)
+    end
+  end
 
-      # The actual UserConfig.load() handles these errors and returns {:error, message}
-      # Validate test structure
-      assert :ok == :ok
+  # Runs `fun` with ECOSYSTEM_MANAGER_CONFIG_DIR pointing at a fresh
+  # temporary directory so UserConfig never touches the developer's real
+  # ~/.config/ecosystem-manager. Overriding HOME does not work for this:
+  # Path.expand/1 resolves `~` via the home directory cached at VM start.
+  # Passes the created config directory to `fun` and always restores the
+  # environment afterwards.
+  defp with_temp_config_dir(fun) do
+    temp_dir = System.tmp_dir!()
+    test_config_dir = Path.join(temp_dir, "test_config_dir_#{:rand.uniform(10_000)}")
+
+    original = System.get_env("ECOSYSTEM_MANAGER_CONFIG_DIR")
+
+    try do
+      System.put_env("ECOSYSTEM_MANAGER_CONFIG_DIR", test_config_dir)
+      File.mkdir_p!(test_config_dir)
+      fun.(test_config_dir)
+    after
+      if original do
+        System.put_env("ECOSYSTEM_MANAGER_CONFIG_DIR", original)
+      else
+        System.delete_env("ECOSYSTEM_MANAGER_CONFIG_DIR")
+      end
+
+      File.rm_rf!(test_config_dir)
     end
   end
 
@@ -240,22 +236,29 @@ defmodule EcosystemManager.UserConfigTest do
       assert String.contains?(expected_content, "import Config")
     end
 
+    test "creates default config file when none exists" do
+      with_temp_config_dir(fn config_dir ->
+        result = UserConfig.create_default_config("/test/workspace")
+
+        case result do
+          {:ok, config_path} ->
+            assert config_path == Path.join(config_dir, "config.exs")
+
+            content = File.read!(config_path)
+            assert String.contains?(content, ~s(workspace_path: "/test/workspace"))
+            assert String.contains?(content, "import Config")
+
+          {:error, reason} ->
+            flunk("Expected success but got error: #{reason}")
+        end
+      end)
+    end
+
     test "returns error when config file already exists" do
-      temp_dir = System.tmp_dir!()
-      test_home = Path.join(temp_dir, "test_exists_home_#{:rand.uniform(10_000)}")
-      test_config_dir = Path.join(test_home, ".config/ecosystem-manager")
-
-      original_home = System.get_env("HOME")
-
-      try do
-        # Override HOME environment variable and create existing config
-        System.put_env("HOME", test_home)
-        File.mkdir_p!(test_config_dir)
-
-        config_path = Path.join(test_config_dir, "config.exs")
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
         File.write!(config_path, "# existing config")
 
-        # Call the function
         result = UserConfig.create_default_config("/test/workspace")
 
         case result do
@@ -265,16 +268,7 @@ defmodule EcosystemManager.UserConfigTest do
           {:ok, _} ->
             flunk("Expected error when config file already exists")
         end
-      after
-        # Restore original HOME
-        if original_home do
-          System.put_env("HOME", original_home)
-        else
-          System.delete_env("HOME")
-        end
-
-        File.rm_rf!(test_home)
-      end
+      end)
     end
   end
 end

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -1,5 +1,9 @@
 defmodule EcosystemManager.UserConfigTest do
-  use ExUnit.Case
+  # async: false is the ExUnit default, but make it explicit: these tests
+  # mutate the ECOSYSTEM_MANAGER_CONFIG_DIR environment variable and the
+  # :ecosystem_manager application env, which are global state.
+  use ExUnit.Case, async: false
+
   alias EcosystemManager.UserConfig
 
   describe "get_config_path/0" do
@@ -30,10 +34,12 @@ defmodule EcosystemManager.UserConfigTest do
             assert String.ends_with?(example_path, "config.example.exs")
 
             content = File.read!(example_path)
+            # Heredoc indentation is trimmed by Elixir, so the generated
+            # file must start at column 0
+            assert String.starts_with?(content, "# EcosystemManager User Configuration")
+            assert String.contains?(content, "\nimport Config\n")
             assert String.contains?(content, "workspace_path:")
-            assert String.contains?(content, "import Config")
             assert String.contains?(content, "repositories:")
-            assert String.contains?(content, "EcosystemManager User Configuration")
 
           {:error, reason} ->
             flunk("Expected success but got error: #{reason}")
@@ -131,6 +137,21 @@ defmodule EcosystemManager.UserConfigTest do
       with_temp_config_dir(fn config_dir ->
         config_path = Path.join(config_dir, "config.exs")
         File.write!(config_path, "invalid elixir syntax {{")
+
+        assert {:error, message} = UserConfig.load()
+        assert message =~ "configuration"
+      end)
+    end
+
+    test "handles config file that throws" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        throw(:boom)
+        """)
 
         assert {:error, message} = UserConfig.load()
         assert message =~ "configuration"
@@ -245,8 +266,11 @@ defmodule EcosystemManager.UserConfigTest do
             assert config_path == Path.join(config_dir, "config.exs")
 
             content = File.read!(config_path)
+            # Heredoc indentation is trimmed by Elixir, so the generated
+            # file must start at column 0
+            assert String.starts_with?(content, "# EcosystemManager User Configuration")
+            assert String.contains?(content, "\nimport Config\n")
             assert String.contains?(content, ~s(workspace_path: "/test/workspace"))
-            assert String.contains?(content, "import Config")
 
           {:error, reason} ->
             flunk("Expected success but got error: #{reason}")

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -1,0 +1,280 @@
+defmodule EcosystemManager.UserConfigTest do
+  use ExUnit.Case
+  alias EcosystemManager.UserConfig
+
+  describe "get_config_path/0" do
+    test "returns expanded config path" do
+      path = UserConfig.get_config_path()
+      assert String.ends_with?(path, "/.config/ecosystem-manager/config.exs")
+      assert String.starts_with?(path, "/")
+    end
+  end
+
+  describe "get_config_dir/0" do
+    test "returns expanded config directory" do
+      dir = UserConfig.get_config_dir()
+      assert String.ends_with?(dir, "/.config/ecosystem-manager")
+      assert String.starts_with?(dir, "/")
+    end
+  end
+
+  describe "create_example_config/0" do
+    test "creates example config file successfully" do
+      # Test in a temporary directory by temporarily overriding the config directory
+      temp_dir = System.tmp_dir!()
+      test_home = Path.join(temp_dir, "test_home_#{:rand.uniform(10_000)}")
+      test_config_dir = Path.join(test_home, ".config/ecosystem-manager")
+
+      original_home = System.get_env("HOME")
+
+      try do
+        # Override HOME environment variable
+        System.put_env("HOME", test_home)
+        File.mkdir_p!(test_config_dir)
+
+        # Call the actual function
+        result = UserConfig.create_example_config()
+
+        case result do
+          {:ok, example_path} ->
+            assert File.exists?(example_path)
+            assert String.ends_with?(example_path, "config.example.exs")
+
+            content = File.read!(example_path)
+            assert String.contains?(content, "workspace_path:")
+            assert String.contains?(content, "import Config")
+            assert String.contains?(content, "repositories:")
+            assert String.contains?(content, "EcosystemManager User Configuration")
+
+          {:error, reason} ->
+            flunk("Expected success but got error: #{reason}")
+        end
+      after
+        # Restore original HOME
+        if original_home do
+          System.put_env("HOME", original_home)
+        else
+          System.delete_env("HOME")
+        end
+
+        File.rm_rf!(test_home)
+      end
+    end
+
+    test "handles file write errors gracefully" do
+      # Test error case by trying to write to a read-only directory
+      # This is hard to test directly, so we'll test the structure
+      temp_dir = System.tmp_dir!()
+      test_config_dir = Path.join(temp_dir, "test_ecosystem_config_#{:rand.uniform(10_000)}")
+
+      try do
+        File.mkdir_p!(test_config_dir)
+        example_path = Path.join(test_config_dir, "config.example.exs")
+
+        # Manually test the content that would be created
+        content = """
+        # EcosystemManager User Configuration
+        # Copy this file to config.exs and customize as needed
+
+        import Config
+
+        # Set your LaTeX ecosystem workspace path
+        # This path will be used as the base directory for all operations
+        config :ecosystem_manager,
+          workspace_path: "~/SynologyDrive/semi/LaTeX/latex-ecosystem"
+        """
+
+        result = File.write(example_path, content)
+        assert result == :ok
+
+        # Verify content structure
+        file_content = File.read!(example_path)
+        assert String.contains?(file_content, "workspace_path:")
+        assert String.contains?(file_content, "import Config")
+      after
+        File.rm_rf!(test_config_dir)
+      end
+    end
+  end
+
+  describe "load/0" do
+    setup do
+      # Save original config values
+      original_workspace = Application.get_env(:ecosystem_manager, :workspace_path)
+      original_repos = Application.get_env(:ecosystem_manager, :repositories)
+
+      on_exit(fn ->
+        # Restore original values
+        if original_workspace do
+          Application.put_env(:ecosystem_manager, :workspace_path, original_workspace)
+        else
+          Application.delete_env(:ecosystem_manager, :workspace_path)
+        end
+
+        if original_repos do
+          Application.put_env(:ecosystem_manager, :repositories, original_repos)
+        else
+          Application.delete_env(:ecosystem_manager, :repositories)
+        end
+      end)
+    end
+
+    test "returns :ok when config file doesn't exist" do
+      # Test with non-existent path by overriding the config path temporarily
+      # Create a module attribute override approach or test the logic directly
+      assert UserConfig.load() == :ok
+    end
+
+    test "loads valid config file and applies settings" do
+      # Test valid config parsing logic without creating files that could
+      # interfere with the compilation process during testing
+
+      # Test the structure that Config.Reader expects
+      config_content = """
+      import Config
+
+      config :ecosystem_manager,
+        workspace_path: "/test/workspace",
+        repositories: ["test-repo1", "test-repo2"]
+      """
+
+      # Verify the content structure is valid by testing string parsing
+      assert String.contains?(config_content, "workspace_path:")
+      assert String.contains?(config_content, "repositories:")
+      assert String.contains?(config_content, "import Config")
+
+      # The actual UserConfig.load() would use Config.Reader.read! in practice
+      # Validate test structure
+      assert :ok == :ok
+    end
+
+    test "handles invalid config file gracefully" do
+      # Test error handling for invalid syntax without creating actual files
+      # that might be processed by the Elixir compiler during testing
+
+      invalid_syntax = "invalid elixir syntax {{"
+
+      # Test that Code.eval_string would fail as expected
+      assert_raise TokenMissingError, fn ->
+        Code.eval_string(invalid_syntax)
+      end
+
+      # The actual UserConfig.load() handles this gracefully with try/rescue
+      # Validate test structure
+      assert :ok == :ok
+    end
+
+    test "handles config file with missing import Config" do
+      # Test that UserConfig.load() handles errors gracefully
+      # This validates the error handling structure in the load() function
+
+      # The load() function uses try/rescue to handle CompileError and SyntaxError
+      # We test that the error handling logic structure is correct
+      error_types = [CompileError, SyntaxError]
+
+      # Verify that these are the expected error types for config issues
+      assert CompileError in error_types
+      assert SyntaxError in error_types
+
+      # The actual UserConfig.load() handles these errors and returns {:error, message}
+      # Validate test structure
+      assert :ok == :ok
+    end
+  end
+
+  describe "create_default_config/1" do
+    test "validates that config creation logic works" do
+      # Test the actual content generation logic without filesystem conflicts
+      workspace = "/test/workspace"
+
+      expected_content = """
+      # EcosystemManager User Configuration
+      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
+
+      import Config
+
+      # Set your LaTeX ecosystem workspace path
+      config :ecosystem_manager,
+        workspace_path: #{inspect(workspace)},
+        
+        # Optional: Custom repository list
+        # repositories: [
+        #   ".",
+        #   "texlive-ja-textlint",
+        #   "latex-environment",
+        #   "sotsuron-template"
+        # ]
+      """
+
+      # Test that the content structure is correct
+      assert String.contains?(expected_content, workspace)
+      assert String.contains?(expected_content, "import Config")
+      assert String.contains?(expected_content, "repositories:")
+    end
+
+    test "validates default workspace path logic" do
+      # Test default path logic
+      default_workspace = "~/path/to/latex-ecosystem"
+
+      expected_content = """
+      # EcosystemManager User Configuration
+      # Generated on #{DateTime.utc_now() |> DateTime.to_string()}
+
+      import Config
+
+      # Set your LaTeX ecosystem workspace path
+      config :ecosystem_manager,
+        workspace_path: #{inspect(default_workspace)},
+        
+        # Optional: Custom repository list
+        # repositories: [
+        #   ".",
+        #   "texlive-ja-textlint",
+        #   "latex-environment",
+        #   "sotsuron-template"
+        # ]
+      """
+
+      # Test that the content structure is correct
+      assert String.contains?(expected_content, default_workspace)
+      assert String.contains?(expected_content, "import Config")
+    end
+
+    test "returns error when config file already exists" do
+      temp_dir = System.tmp_dir!()
+      test_home = Path.join(temp_dir, "test_exists_home_#{:rand.uniform(10_000)}")
+      test_config_dir = Path.join(test_home, ".config/ecosystem-manager")
+
+      original_home = System.get_env("HOME")
+
+      try do
+        # Override HOME environment variable and create existing config
+        System.put_env("HOME", test_home)
+        File.mkdir_p!(test_config_dir)
+
+        config_path = Path.join(test_config_dir, "config.exs")
+        File.write!(config_path, "# existing config")
+
+        # Call the function
+        result = UserConfig.create_default_config("/test/workspace")
+
+        case result do
+          {:error, message} ->
+            assert String.contains?(message, "already exists")
+
+          {:ok, _} ->
+            flunk("Expected error when config file already exists")
+        end
+      after
+        # Restore original HOME
+        if original_home do
+          System.put_env("HOME", original_home)
+        else
+          System.delete_env("HOME")
+        end
+
+        File.rm_rf!(test_home)
+      end
+    end
+  end
+end

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,7 @@ TEMPLATE_REPOS=(
 
 TOOL_REPOS=(
     "thesis-management-tools"
+    "thesis-student-registry"
     "ai-academic-paper-reviewer"
     "aldc"
 )


### PR DESCRIPTION
Resolves #79
Resolves #82

## 概要

setup.sh・ECOSYSTEM.md・ecosystem-manager 間のリポジトリ一覧の不整合を解消し、作業中に発覚した `.gitignore` によるソースファイルのコミット漏れ（#82）を修正します。

## 変更内容

### リポジトリ一覧の整合 (#79)

- **setup.sh**: `TOOL_REPOS` に `thesis-student-registry` を追加。fresh setup で ecosystem-manager が管理する全リポジトリが clone されるようにする
- **repository.ex**: `@default_repositories` に `poster-template` を追加。ユーザー設定なしの新規開発者にも status で表示されるようにする
- **テスト追加**: デフォルト一覧に全テンプレートリポジトリが含まれることを検証するテストを追加（TDD: 修正前に失敗することを確認済み）
- **README**: 非公開リポジトリ（`thesis-student-registry` 等）の clone には gh 認証または SSH 鍵が必要な旨を追記（匿名 HTTPS フォールバックは公開リポジトリのみ）

### .gitignore 修正とコミット漏れファイルの追加 (#82)

- `.gitignore` に `!ecosystem_manager/**` を追加。`*/` ルールが `ecosystem_manager/lib` などのサブディレクトリにも一致するため、単独の `!ecosystem_manager/` では配下の新規ファイルがサイレントに無視されていた（`.github` で対処済みの落とし穴と同一）
- コミット漏れしていたソース・設定・テスト 12 ファイルを追加（`application.ex`, `config.ex`, `user_config.ex`, `config/test.exs`, `config/config.example.exs`, テストスイート一式）
- ビルド成果物（`_build/`, `deps/`, escript バイナリ等）は `ecosystem_manager/.gitignore` により引き続き除外されることを確認済み

## 検証

- `mix test`: 145 件全成功（新規テスト含む）
- `mix format --check-formatted`: クリーン
- `bash -n` / `shellcheck setup.sh`: クリーン
- **fresh clone 相当の検証**: `git archive HEAD` で取り出したコミット済みツリーのみから `mix deps.get && mix escript.build` が成功し、escript が正常動作することを確認
- 比較として修正前 (HEAD~1) のツリーではビルドは通るものの、escript 起動時に `UndefinedFunctionError: EcosystemManager.Application.start/2 is undefined` で全コマンドがクラッシュすることを確認（#82 の実害）

## 補足

- `mix credo --strict` は credo 1.7.12 と Elixir 1.20 の非互換で変更前からクラッシュする既存問題があります（本 PR のスコープ外）