### PR TITLE
Detect existing checkout in setup.sh to avoid nested clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,25 @@ gh auth status
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/latex-ecosystem/main/setup.sh)"
 ```
 
+This creates a `latex-ecosystem-dev/` directory under the current directory
+and sets up everything inside it.
+
 **Manual clone and setup:**
 ```bash
 gh repo clone smkwlab/latex-ecosystem latex-ecosystem-dev
 cd latex-ecosystem-dev
 ./setup.sh
+```
+
+When run inside an existing latex-ecosystem checkout, `setup.sh` detects it
+and clones the component repositories into that checkout instead of creating
+a nested `latex-ecosystem-dev/`.
+
+**Custom location:**
+```bash
+# Set LATEX_ECOSYSTEM_BASE to control where the ecosystem is set up
+LATEX_ECOSYSTEM_BASE="$HOME/work/latex-ecosystem" \
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/latex-ecosystem/main/setup.sh)"
 ```
 
 ### Daily Ecosystem Management

--- a/setup.sh
+++ b/setup.sh
@@ -91,7 +91,8 @@ setup_base_directory() {
     echo -e "\nSetting up base directory..."
 
     if [ -n "${LATEX_ECOSYSTEM_BASE:-}" ]; then
-        # Explicit override always wins
+        # Explicit override always wins (checkout detection still applies
+        # to the chosen directory below)
         BASE_DIR="$LATEX_ECOSYSTEM_BASE"
     elif is_ecosystem_checkout "$(pwd)"; then
         # Running inside an existing latex-ecosystem checkout (README's

--- a/setup.sh
+++ b/setup.sh
@@ -82,24 +82,44 @@ check_prerequisites() {
     fi
 }
 
+# Return success if the given directory is a latex-ecosystem checkout
+is_ecosystem_checkout() {
+    [ -d "$1/.git" ] && [ -f "$1/ecosystem_manager/mix.exs" ]
+}
+
 setup_base_directory() {
     echo -e "\nSetting up base directory..."
-    
-    # Use environment variable or current directory
-    BASE_DIR="${LATEX_ECOSYSTEM_BASE:-$(pwd)/latex-ecosystem-dev}"
-    
+
+    if [ -n "${LATEX_ECOSYSTEM_BASE:-}" ]; then
+        # Explicit override always wins
+        BASE_DIR="$LATEX_ECOSYSTEM_BASE"
+    elif is_ecosystem_checkout "$(pwd)"; then
+        # Running inside an existing latex-ecosystem checkout (README's
+        # "Manual clone and setup" flow): use it as-is instead of nesting
+        # a second latex-ecosystem-dev inside it
+        BASE_DIR="$(pwd)"
+        print_status "Using existing latex-ecosystem checkout: $BASE_DIR"
+        return
+    else
+        BASE_DIR="$(pwd)/latex-ecosystem-dev"
+    fi
+
     if [ -d "$BASE_DIR" ]; then
-        print_warning "Directory $BASE_DIR already exists"
-        read -p "Continue anyway? (y/N) " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            exit 1
+        if is_ecosystem_checkout "$BASE_DIR"; then
+            print_status "Using existing latex-ecosystem checkout: $BASE_DIR"
+        else
+            print_warning "Directory $BASE_DIR already exists"
+            read -p "Continue anyway? (y/N) " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                exit 1
+            fi
         fi
     else
         mkdir -p "$BASE_DIR"
         print_status "Created directory: $BASE_DIR"
     fi
-    
+
     cd "$BASE_DIR"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -96,10 +96,9 @@ setup_base_directory() {
     elif is_ecosystem_checkout "$(pwd)"; then
         # Running inside an existing latex-ecosystem checkout (README's
         # "Manual clone and setup" flow): use it as-is instead of nesting
-        # a second latex-ecosystem-dev inside it
+        # a second latex-ecosystem-dev inside it. The common path below
+        # prints the status message and cd is a no-op.
         BASE_DIR="$(pwd)"
-        print_status "Using existing latex-ecosystem checkout: $BASE_DIR"
-        return
     else
         BASE_DIR="$(pwd)/latex-ecosystem-dev"
     fi


### PR DESCRIPTION
Resolves #80

## 概要

README の「Manual clone and setup」手順（clone → cd → `./setup.sh`）を実行すると、clone 済みチェックアウトの中に `latex-ecosystem-dev/` を入れ子に作って全リポジトリを二重 clone してしまう問題を修正します。

## 変更内容

### setup.sh
- `is_ecosystem_checkout()` ヘルパーを追加（`.git` と `ecosystem_manager/mix.exs` の存在で判定）
- `setup_base_directory()` の判定ロジックを整理:
  1. `LATEX_ECOSYSTEM_BASE` が設定されていれば常に優先（従来どおり）
  2. カレントディレクトリが latex-ecosystem チェックアウトなら**そこをそのまま使用**（入れ子を作らない）
  3. それ以外は従来どおり `$(pwd)/latex-ecosystem-dev` を作成
- `LATEX_ECOSYSTEM_BASE` が既存のチェックアウトを指す場合は「already exists」の確認プロンプトをスキップ

### README.md
- ワンライナー実行が `latex-ecosystem-dev/` を作ることを明記
- チェックアウト内実行時の自動検出の説明を追加
- これまで未文書化だった `LATEX_ECOSYSTEM_BASE` による配置先指定を文書化

## 検証（いずれも実際にフル実行）

1. **チェックアウト内実行**: 本ブランチの local clone 内で `setup.sh` を実行 → `Using existing latex-ecosystem checkout` と表示され、入れ子ディレクトリなし、全 13 コンポーネント（#79 で追加した `thesis-student-registry` 含む）がチェックアウト直下に clone され、escript ビルドと最終の `ecosystem-manager status` まで成功（exit 0）
2. **従来動作（回帰確認）**: 空ディレクトリから実行 → 従来どおり `latex-ecosystem-dev/` が作成されその中に構築、exit 0
3. `bash -n` / `shellcheck`: クリーン