### PR TITLE
Relax ecosystem_manager Elixir requirement to ~> 1.17

### DIFF
--- a/ecosystem_manager/mix.exs
+++ b/ecosystem_manager/mix.exs
@@ -5,8 +5,8 @@ defmodule EcosystemManager.MixProject do
     [
       app: :ecosystem_manager,
       version: "0.1.0",
-      # Keep in sync with the org-standard CI LTS lane
-      # (smkwlab/.github elixir-ci.yml: Elixir 1.17 / OTP 27)
+      # Keep in sync with the LTS Elixir lane of the org-standard CI
+      # (smkwlab/.github elixir-ci.yml)
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/ecosystem_manager/mix.exs
+++ b/ecosystem_manager/mix.exs
@@ -5,7 +5,9 @@ defmodule EcosystemManager.MixProject do
     [
       app: :ecosystem_manager,
       version: "0.1.0",
-      elixir: "~> 1.18",
+      # Keep in sync with the org-standard CI LTS lane
+      # (smkwlab/.github elixir-ci.yml: Elixir 1.17 / OTP 27)
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: [main_module: EcosystemManager.CLI, name: "ecosystem-manager"],


### PR DESCRIPTION
Resolves #85

## 概要

`ecosystem_manager/mix.exs` の Elixir 要求バージョンを `~> 1.18` から `~> 1.17` に緩和します。org 標準 CI の LTS レーンと同期する旨のコメントも追加しました。

## 背景

- `~> 1.18` は初回実装 PR #34 時の手元バージョンをそのまま書いたもので、**1.18 固有機能は不使用**（組み込み `JSON` モジュール等の使用なし。JSON は `jason` 依存）
- org 標準 CI（`smkwlab/.github` の `elixir-ci.yml`）は LTS = **Elixir 1.17.3 / OTP 27.3.4.4** のレーンを持つため、`~> 1.18` のままでは導入時に LTS レーンが `mix` のバージョンチェックで即失敗する
- 兄弟プロジェクト（registry_manager / thesis_monitor は `~> 1.14`）との整合も改善

## 検証

| 環境 | 結果 |
|---|---|
| Elixir 1.17.3-otp-27 / Erlang 27.3.4.4（org CI LTS 相当） | `mix compile --warnings-as-errors` クリーン、テスト 148 件全成功、escript ビルド・実行正常 |
| Elixir 1.20.2-otp-29（現行開発環境） | テスト 148 件全成功、`mix format --check-formatted` クリーン |

`~> 1.14` まで下げる案は 1.14〜1.16 が未検証のため見送り、エビデンスのある `~> 1.17`（org CI の LTS フロアと一致）としました。