### PR TITLE
Report failures and exit non-zero in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,10 @@ GITHUB_ORG="smkwlab"
 
 # Failure tracking: individual failures do not stop the run (graceful
 # degradation), but they are summarized at the end and reflected in the
-# exit code so scripted callers can detect a partial setup
+# exit code so scripted callers can detect a partial setup.
+# NOTE: functions that update these (clone_repositories,
+# setup_ecosystem_management) must be called directly, never via a
+# subshell ($(...) or (...)), or the updates are lost.
 FAILED_CLONES=()
 BUILD_FAILED=0
 
@@ -278,7 +281,9 @@ main() {
     if [ ${#FAILED_CLONES[@]} -gt 0 ] || [ "$BUILD_FAILED" -eq 1 ]; then
         echo ""
         if [ ${#FAILED_CLONES[@]} -gt 0 ]; then
-            print_error "Failed to clone: ${FAILED_CLONES[*]}"
+            for repo in "${FAILED_CLONES[@]}"; do
+                print_error "Failed to clone: $repo"
+            done
         fi
         if [ "$BUILD_FAILED" -eq 1 ]; then
             print_error "ecosystem-manager escript build failed"

--- a/setup.sh
+++ b/setup.sh
@@ -133,6 +133,8 @@ setup_base_directory() {
 }
 
 setup_ecosystem_management() {
+    # IMPORTANT: call directly (not via $(...) or (...)) so that
+    # BUILD_FAILED updates are visible to the caller
     echo -e "\nSetting up ecosystem management..."
     
     # Clone latex-ecosystem repository
@@ -165,6 +167,9 @@ setup_ecosystem_management() {
                 BUILD_FAILED=1
             fi
         else
+            # Deliberately NOT counted as a failure: Elixir/Mix is an
+            # optional prerequisite (see check_prerequisites), so a skipped
+            # build only warns and the script can still exit 0
             print_warning "Skipping ecosystem-manager build (Elixir/Mix not found). Build later: cd ecosystem_manager && mix escript.build"
         fi
     else
@@ -174,6 +179,8 @@ setup_ecosystem_management() {
 }
 
 clone_repositories() {
+    # IMPORTANT: call directly (not via $(...) or (...)) so that
+    # FAILED_CLONES updates are visible to the caller
     local repos=("$@")
     for repo in "${repos[@]}"; do
         if [ -d "$repo" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,12 @@ NC='\033[0m' # No Color
 ECOSYSTEM_REPO="https://github.com/smkwlab/latex-ecosystem"
 GITHUB_ORG="smkwlab"
 
+# Failure tracking: individual failures do not stop the run (graceful
+# degradation), but they are summarized at the end and reflected in the
+# exit code so scripted callers can detect a partial setup
+FAILED_CLONES=()
+BUILD_FAILED=0
+
 # Repository lists
 CORE_REPOS=(
     "texlive-ja-textlint"
@@ -153,6 +159,7 @@ setup_ecosystem_management() {
                 print_status "ecosystem-manager is ready"
             else
                 print_warning "Failed to build ecosystem-manager (build it later: cd ecosystem_manager && mix escript.build)"
+                BUILD_FAILED=1
             fi
         else
             print_warning "Skipping ecosystem-manager build (Elixir/Mix not found). Build later: cd ecosystem_manager && mix escript.build"
@@ -182,6 +189,7 @@ clone_repositories() {
                         print_status "Cloned $repo (HTTPS)"
                     else
                         print_error "Failed to clone $repo"
+                        FAILED_CLONES+=("$repo")
                     fi
                 fi
             else
@@ -192,6 +200,7 @@ clone_repositories() {
                     print_status "Cloned $repo (HTTPS)"
                 else
                     print_error "Failed to clone $repo"
+                    FAILED_CLONES+=("$repo")
                 fi
             fi
         fi
@@ -257,16 +266,31 @@ main() {
     echo -e "\nVerifying setup..."
     if [ -x ecosystem_manager/ecosystem-manager ]; then
         ./ecosystem_manager/ecosystem-manager status
-        print_status "Setup completed successfully!"
-        echo -e "\nNext steps:"
-        echo "  cd $BASE_DIR"
-        echo "  ./ecosystem_manager/ecosystem-manager status --long"
     else
-        print_warning "Setup completed, but ecosystem-manager is not built yet."
+        print_warning "ecosystem-manager is not built yet."
         echo -e "\nTo build it:"
         echo "  cd $BASE_DIR/ecosystem_manager && mix escript.build"
         echo "  ./ecosystem_manager/ecosystem-manager status"
     fi
+
+    # Failure summary: report everything that went wrong during the run
+    # and exit non-zero so scripted callers can detect a partial setup
+    if [ ${#FAILED_CLONES[@]} -gt 0 ] || [ "$BUILD_FAILED" -eq 1 ]; then
+        echo ""
+        if [ ${#FAILED_CLONES[@]} -gt 0 ]; then
+            print_error "Failed to clone: ${FAILED_CLONES[*]}"
+        fi
+        if [ "$BUILD_FAILED" -eq 1 ]; then
+            print_error "ecosystem-manager escript build failed"
+        fi
+        print_error "Setup finished with errors (see above)"
+        exit 1
+    fi
+
+    print_status "Setup completed successfully!"
+    echo -e "\nNext steps:"
+    echo "  cd $BASE_DIR"
+    echo "  ./ecosystem_manager/ecosystem-manager status --long"
 }
 
 # Run main function


### PR DESCRIPTION
Resolves #81

## 概要

setup.sh が clone 失敗や escript ビルド失敗があっても exit 0 で「Setup completed successfully!」と報告する問題を修正します。

## 変更内容

- clone に失敗したリポジトリを `FAILED_CLONES` 配列に記録（gh あり/なし両方のフォールバック経路）
- ビルドを**試行して失敗**した場合に `BUILD_FAILED=1` を記録（Elixir/Mix 不在によるスキップは従来どおり警告のみ。前提条件チェックで optional 扱いのため）
- 最後に失敗サマリ（`Failed to clone: ...` 等）を表示し、1 件でも失敗があれば **exit 1**
- `Setup completed successfully!` は失敗ゼロのときのみ表示（従来は失敗があっても表示され矛盾していた）
- 途中で止めない graceful degradation の挙動は維持

## 検証（すべて実行済み）

| ケース | 結果 |
|---|---|
| 成功パス（フル実行） | 従来どおり全 clone・ビルド・status 実行後、`Setup completed successfully!` で **exit 0** |
| 失敗パス（存在しないリポジトリを TOOL_REPOS に注入してフル実行） | 途中で止まらず最後まで実行後、サマリ `Failed to clone: no-such-repo-e2e-81` → `Setup finished with errors` で **exit 1** |
| 関数単体（clone_repositories に存在しないリポジトリ） | `FAILED_CLONES` に記録され、ループは継続 |
| `bash -n` / `shellcheck` | クリーン |

実装メモ: `set -e` 下のため、サマリ判定は `[ ... ] && cmd` の短絡形ではなく if 文で記述しています。