### PR TITLE
registry-manager / thesis-monitor 分離に伴うドキュメント更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,12 @@ repository.
 >
 > The tool also needs `~/.config/registry-manager/config.json` with at least
 > `{"github_org": "smkwlab", "data_repo": "smkwlab/thesis-student-registry"}`.
+> Authentication uses the GitHub CLI (`gh auth login`) — no token key in the
+> config file. See the [registry-manager README](https://github.com/smkwlab/registry-manager#readme)
+> for all configuration keys.
 
 ```bash
-# (run from the directory containing the registry-manager checkout)
+# (run from the parent directory of the registry-manager checkout)
 
 # Check what would be done (dry-run)
 ./registry-manager/registry-manager propagate-workflow k22rs001-sotsuron --dry-run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ This directory contains multiple **independent Git repositories**:
 
 ### Management & Monitoring
 - **thesis-management-tools/**: Repository creation and branch protection automation
-- **thesis-student-registry/**: Secure student repository registry and monitoring tools
+- **thesis-student-registry/**: Secure student repository registry data (private, data-only)
+- **registry-manager/**: Registry data management tool (Elixir escript, separate repo)
+- **thesis-monitor/**: Student repository monitoring tool (Elixir escript, separate repo)
 - **latex-ecosystem/**: This management repository for ecosystem coordination
 
 ### GitHub Actions
@@ -147,32 +149,35 @@ thesis-monitor status --verbose
 #### Correct Procedure (Automated)
 
 Use the `propagate-workflow` command of `registry-manager`, the Elixir escript
-located in the `registry_manager/` directory of the `thesis-student-registry`
+maintained in the [smkwlab/registry-manager](https://github.com/smkwlab/registry-manager)
 repository.
 
-> **Prerequisite**: All commands below are run from the `thesis-student-registry`
-> checkout root. Build the escript first (also from that root):
+> **Prerequisite**: Clone and build the escript first:
 > ```bash
-> (cd registry_manager && mix escript.build)
+> git clone git@github.com:smkwlab/registry-manager.git
+> (cd registry-manager && mix escript.build)
 > ```
-> Without this build step the `./registry_manager/registry-manager` binary does
+> Without this build step the `./registry-manager/registry-manager` binary does
 > not exist yet, so the command fails (the exact wording varies by shell/OS, e.g.
 > "No such file or directory").
+>
+> The tool also needs `~/.config/registry-manager/config.json` with at least
+> `{"github_org": "smkwlab", "data_repo": "smkwlab/thesis-student-registry"}`.
 
 ```bash
-# (run from the thesis-student-registry checkout root)
+# (run from the directory containing the registry-manager checkout)
 
 # Check what would be done (dry-run)
-./registry_manager/registry-manager propagate-workflow k22rs001-sotsuron --dry-run
+./registry-manager/registry-manager propagate-workflow k22rs001-sotsuron --dry-run
 
 # Propagate workflow updates for a single repository
-./registry_manager/registry-manager propagate-workflow k22rs001-sotsuron
+./registry-manager/registry-manager propagate-workflow k22rs001-sotsuron
 
 # Propagate to all thesis repositories at once
-./registry_manager/registry-manager propagate-workflow --all --type thesis
+./registry-manager/registry-manager propagate-workflow --all --type thesis
 
 # Check all repositories first
-./registry_manager/registry-manager propagate-workflow --all --type thesis --dry-run
+./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
 ```
 
 #### Manual Procedure (if needed)
@@ -240,5 +245,5 @@ gh pr diff <PR_NUMBER> --repo smkwlab/<repo> | grep -E "\.github/workflows"
 
 - **ai-reviewer**: Fork maintained here due to upstream bugs
 - **ai-academic-paper-reviewer**: Developed based on `ai-reviewer`.
-- **thesis-monitor**: Elixir-based monitoring tool with CSV integration
+- **thesis-monitor**: Elixir-based monitoring tool with CSV integration (own repository: smkwlab/thesis-monitor)
 - **Cross-repository Coordination**: All repositories work together as unified system

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -54,7 +54,7 @@ Supporting Infrastructure:
 ├── aldc → latex-environment (release branch)
 ├── thesis-management-tools → (Management workflows)
 ├── thesis-student-registry → (Student repository registry data, private)
-├── registry-manager → thesis-student-registry (manages registry data via GitHub API)
+├── registry-manager → thesis-student-registry (writes registry data)
 └── thesis-monitor → thesis-student-registry (reads registry data)
 ```
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -19,7 +19,9 @@ This document describes the architecture and management strategy for the thesis-
 
 ### Management & Automation
 - **thesis-management-tools**: Administrative tools and documentation for thesis supervision
-- **thesis-student-registry**: Student repository registry and monitoring tools (registry-manager / thesis-monitor escripts)
+- **thesis-student-registry**: Student repository registry data (private, data-only)
+- **registry-manager**: Registry data management tool (Elixir escript)
+- **thesis-monitor**: Student repository monitoring tool (Elixir escript)
 - **ai-academic-paper-reviewer**: GitHub Action for automated review via the org-standard AI review workflow; supports both `ACADEMIC` (paper) and `CODE` review modes, so it is the single AI reviewer for the ecosystem
 - **ai-reviewer** (legacy): standalone code-review Action hosted at `toshi0806/ai-reviewer` (a fork of `Nasubikun/ai-reviewer`). Superseded by `ai-academic-paper-reviewer` (`CODE` mode) and no longer used by the migrated workflows; kept for reference only
 - **aldc**: Command-line tool for adding LaTeX devcontainer to repositories
@@ -51,7 +53,9 @@ Supporting Infrastructure:
 ├── ai-academic-paper-reviewer → (AI review for thesis repos & code review, ACADEMIC/CODE modes)
 ├── aldc → latex-environment (release branch)
 ├── thesis-management-tools → (Management workflows)
-└── thesis-student-registry → (Student repository registry & monitoring)
+├── thesis-student-registry → (Student repository registry data, private)
+├── registry-manager → thesis-student-registry (manages registry data via GitHub API)
+└── thesis-monitor → thesis-student-registry (reads registry data)
 ```
 
 ## Version Compatibility


### PR DESCRIPTION
## 概要

smkwlab/thesis-student-registry#128 の Phase 5。thesis-student-registry のデータ専用化とツール分離（smkwlab/registry-manager, smkwlab/thesis-monitor）に伴うエコシステムドキュメントの追従。

## 変更内容

- **CLAUDE.md**
  - Repository Structure に registry-manager / thesis-monitor を追加、thesis-student-registry を「データ専用（private）」に変更
  - propagate-workflow の実行手順を新リポジトリ配置に更新（clone・ビルド手順、必要な `~/.config/registry-manager/config.json` の記載）
- **ECOSYSTEM.md**: コンポーネント一覧と依存グラフを 3 リポジトリ構成に更新

## 関連 PR

- smkwlab/thesis-student-registry#129（データ専用化）
- smkwlab/thesis-management-tools#466（ツールパス追従）
- smkwlab/registry-manager#1, #2（汎用化・ドキュメント）

Refs smkwlab/thesis-student-registry#128