### PR TITLE
docs: unify registry terminology and fix pre-split tool instructions

### DIFF
--- a/.github/scripts/build-dashboard.sh
+++ b/.github/scripts/build-dashboard.sh
@@ -84,8 +84,8 @@ gh workflow run update-release-branch.yml --repo ${OWNER}/latex-environment
 ## 🎓 学生リポジトリへの伝播（latex-ecosystem ルートから）
 
 \`\`\`bash
-git clone git@github.com:smkwlab/registry-manager.git   # 初回のみ
-(cd registry-manager && mix escript.build)              # 初回のみ
+[ -d registry-manager ] || git clone git@github.com:smkwlab/registry-manager.git
+(cd registry-manager && mix escript.build)   # 初回のみ
 ./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
 ./registry-manager/registry-manager propagate-workflow --all --type thesis
 \`\`\`

--- a/.github/scripts/build-dashboard.sh
+++ b/.github/scripts/build-dashboard.sh
@@ -81,11 +81,12 @@ gh workflow run check-texlive-updates.yml --repo ${OWNER}/latex-environment
 gh workflow run update-release-branch.yml --repo ${OWNER}/latex-environment
 \`\`\`
 
-## 🎓 学生リポジトリへの伝播（thesis-student-registry チェックアウトのルートから）
+## 🎓 学生リポジトリへの伝播（latex-ecosystem ルートから）
 
 \`\`\`bash
-(cd registry_manager && mix escript.build)   # 初回のみ
-./registry_manager/registry-manager propagate-workflow --all --type thesis --dry-run
-./registry_manager/registry-manager propagate-workflow --all --type thesis
+git clone git@github.com:smkwlab/registry-manager.git   # 初回のみ
+(cd registry-manager && mix escript.build)              # 初回のみ
+./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
+./registry-manager/registry-manager propagate-workflow --all --type thesis
 \`\`\`
 EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,8 @@ Use the **`/propagate` skill** ([.claude/skills/propagate/SKILL.md](.claude/skil
 
 ## Security & Data Management
 
-- **Student Data Separation**: `thesis-student-registry` repository keeps student information separate for security
-- **Automated Registry Updates**: GitHub Actions automatically update student repository lists
+- **Registry Data Separation**: student information lives only in the private registry data repository (`thesis-student-registry`), separate from tools and templates
+- **Automated Registry Updates**: GitHub Actions automatically update the registry (`data/repositories.json`)
 - **Branch Protection**: Automatic setup for PR-based review workflows
 - **Access Control**: Fine-grained permissions for different user roles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Use the **`/propagate` skill** ([.claude/skills/propagate/SKILL.md](.claude/skil
 ## Security & Data Management
 
 - **Registry Data Separation**: student information lives only in the private registry data repository (`thesis-student-registry`), separate from tools and templates
-- **Automated Registry Updates**: GitHub Actions automatically update the registry (`data/repositories.json`)
+- **Automated Registry Updates**: GitHub Actions automatically update the registry (`data/registry.json`)
 - **Branch Protection**: Automatic setup for PR-based review workflows
 - **Access Control**: Fine-grained permissions for different user roles
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -140,6 +140,27 @@ Supporting Infrastructure:
 
 ## Cross-Repository Standards
 
+### Terminology: Student Repository Registry
+
+The ecosystem uses **"registry"** consistently for the student-repository ledger:
+
+- **Registry**: the ledger of student repositories, materialized as `data/repositories.json`
+  in the registry data repository. Use "registry (data)" in docs — avoid ad-hoc synonyms
+  such as "student data", "student repository list", or "リポジトリ一覧" for the same thing.
+- **Registry data repository**: `thesis-student-registry` (private, data-only).
+  Test counterpart: `thesis-student-registry-test` (naming rule: `<production-name>-test`).
+- **Tool naming**: prefix = the object the tool operates on, suffix = its role
+  (read = *monitor*, write = *manager*). Hence `registry-manager` writes the registry,
+  while `thesis-monitor` reads the registry as an index to monitor student thesis
+  repositories. The prefix asymmetry is intentional — the two tools operate on
+  different objects.
+- **Data fields**: registry-managed timestamps carry the `registry_` prefix
+  (`registry_created_at`, `registry_updated_at`); bare `created_at`/`updated_at` are
+  legacy fields (see registry-manager data-structure spec for migration status).
+- **Disambiguation**: "registry" in container/image contexts (texlive-ja-textlint,
+  devcontainer docs) means **GitHub Container Registry (ghcr.io)** and is unrelated;
+  always spell it out fully there.
+
 ### File Naming Conventions
 - **CLAUDE.md**: Project-specific Claude Code instructions
 - **README.md**: User-facing documentation  

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -144,7 +144,8 @@ Supporting Infrastructure:
 
 The ecosystem uses **"registry"** consistently for the student-repository ledger:
 
-- **Registry**: the ledger of student repositories, materialized as `data/repositories.json`
+- **Registry**: the ledger of student repositories, materialized as `data/registry.json`
+  (renamed from `repositories.json` in 2026-07; tools keep a one-generation fallback)
   in the registry data repository. Use "registry (data)" in docs — avoid ad-hoc synonyms
   such as "student data", "student repository list", or "リポジトリ一覧" for the same thing.
 - **Registry data repository**: `thesis-student-registry` (private, data-only).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ latex-ecosystem/
 #
 #   Management & automation
 ├── thesis-management-tools/  # Repository creation / review tooling
-├── thesis-student-registry/  # Student repository registry & monitoring
+├── thesis-student-registry/  # Student repository registry data (private, data-only)
 ├── ai-academic-paper-reviewer/ # AI review Action (ACADEMIC/CODE modes)
 └── aldc/                     # Adds the LaTeX devcontainer to a repository
 ```
@@ -205,7 +205,7 @@ Supporting Infrastructure:
 ├── ai-academic-paper-reviewer → (AI review for thesis repos & code review, ACADEMIC/CODE modes)
 ├── aldc → latex-environment (release branch)
 ├── thesis-management-tools → (Management workflows)
-└── thesis-student-registry → (Student repository registry & monitoring)
+└── thesis-student-registry → (Student repository registry data; managed by registry-manager, read by thesis-monitor)
 ```
 
 ## Support

--- a/docs/CLAUDE-ARCHITECTURE.md
+++ b/docs/CLAUDE-ARCHITECTURE.md
@@ -62,7 +62,7 @@ latex-ecosystem/                 # This management repository
 
 #### Tools and Automation
 - **thesis-management-tools/**: Administrative tools and workflows
-- **thesis-student-registry/**: Student repository registry and monitoring
+- **thesis-student-registry/**: Student repository registry data (private, data-only; written by registry-manager, read by thesis-monitor)
 - **latex-release-action/**: GitHub Action for LaTeX compilation
 - **ai-academic-paper-reviewer/**: GitHub Action for automated review (ACADEMIC and CODE modes)
 - **aldc/**: Command-line tool for adding LaTeX devcontainer
@@ -94,7 +94,7 @@ wr-template, latex-template, poster-template (templates)
     ↓
 thesis-management-tools (student workflows)
     ↓
-thesis-student-registry (registry & monitoring)
+thesis-student-registry (registry data)
 ```
 
 ### Update Propagation

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -234,21 +234,25 @@ git checkout 0th-draft  # または指定されたブランチ
 
 #### B. レジストリ管理
 
-> **前提**: registry-manager は独立リポジトリ（[smkwlab/registry-manager](https://github.com/smkwlab/registry-manager)）。
-> latex-ecosystem ルートに clone して escript をビルドしておく:
+> **前提**: registry-manager / thesis-monitor はいずれも独立リポジトリ
+> （[smkwlab/registry-manager](https://github.com/smkwlab/registry-manager) /
+> [smkwlab/thesis-monitor](https://github.com/smkwlab/thesis-monitor)）。
+> latex-ecosystem ルートに clone して escript をビルドしておく（初回のみ）:
 > ```bash
-> git clone git@github.com:smkwlab/registry-manager.git
+> [ -d registry-manager ] || git clone git@github.com:smkwlab/registry-manager.git
 > (cd registry-manager && mix escript.build)
+> [ -d thesis-monitor ] || git clone git@github.com:smkwlab/thesis-monitor.git
+> (cd thesis-monitor && mix deps.get && mix escript.build)
 > ```
-> 未ビルドだと `./registry-manager/registry-manager` が存在せずコマンドが失敗する。
+> 未ビルドだと `./registry-manager/registry-manager` 等が存在せずコマンドが失敗する。
 
 ```bash
 # レジストリ操作・workflow 伝播（latex-ecosystem ルートから実行）
 ./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
 
-# 学生リポジトリの進捗・保護状況の監視は thesis-monitor（独立リポジトリ smkwlab/thesis-monitor）で行う
-thesis-monitor status
-thesis-monitor status --show-protection
+# 学生リポジトリの進捗・保護状況の監視は thesis-monitor で行う
+./thesis-monitor/thesis-monitor status
+./thesis-monitor/thesis-monitor status --show-protection
 ```
 
 ### 2. 品質管理システム

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -234,19 +234,21 @@ git checkout 0th-draft  # または指定されたブランチ
 
 #### B. レジストリ管理
 
-> **前提**: 以下は `thesis-student-registry` チェックアウトのルートから実行する。
-> 初回はその前に escript をビルドしておく（ルートから）:
+> **前提**: registry-manager は独立リポジトリ（[smkwlab/registry-manager](https://github.com/smkwlab/registry-manager)）。
+> latex-ecosystem ルートに clone して escript をビルドしておく:
 > ```bash
-> (cd registry_manager && mix escript.build)
+> git clone git@github.com:smkwlab/registry-manager.git
+> (cd registry-manager && mix escript.build)
 > ```
-> 未ビルドだと `./registry_manager/registry-manager` が存在せずコマンドが失敗する。
+> 未ビルドだと `./registry-manager/registry-manager` が存在せずコマンドが失敗する。
 
 ```bash
-# 進捗監視（thesis-student-registry チェックアウトのルートから実行）
-./registry_manager/registry-manager status
+# レジストリ操作・workflow 伝播（latex-ecosystem ルートから実行）
+./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
 
-# 保護状況確認  
-./registry_manager/registry-manager status --show-protection
+# 学生リポジトリの進捗・保護状況の監視は thesis-monitor（独立リポジトリ smkwlab/thesis-monitor）で行う
+thesis-monitor status
+thesis-monitor status --show-protection
 ```
 
 ### 2. 品質管理システム
@@ -333,7 +335,8 @@ branches:
 - [学生作品例3](http://www-st.is.kyusan-u.ac.jp/~k22rs004/semi3a/)
 
 ### 管理ツール
-- [registry-manager](../thesis-student-registry/registry_manager/)
+- [registry-manager](https://github.com/smkwlab/registry-manager)（レジストリ書き込み・workflow 伝播）
+- [thesis-monitor](https://github.com/smkwlab/thesis-monitor)（学生リポジトリの監視）
 - [thesis-management-tools](../thesis-management-tools/)
 
 ---


### PR DESCRIPTION
## 概要

エコシステム全体の「registry」用語調査（2026-07-05）で見つかった呼称ゆれと、ツール分離（thesis-student-registry #128）前の古い手順記述を解消する。

## 変更内容

- **ECOSYSTEM.md**: Cross-Repository Standards に用語規約セクションを新設
  - registry = `data/repositories.json` を核とする学生リポジトリ台帳（「student data」「student repository list」等の同義語を使わない）
  - ツール命名規則: prefix = 操作対象 / suffix = 役割（read = monitor, write = manager）。registry-manager と thesis-monitor の prefix 非対称は意図的である旨を明文化
  - テスト repo 命名は `<本番名>-test`、`registry_` フィールド prefix、GitHub Container Registry（同音異義語）の書き分け
- **CLAUDE.md / README.md / docs/CLAUDE-ARCHITECTURE.md**: thesis-student-registry の説明を「registry & monitoring」（monitoring は thesis-monitor に分離済みで古い）から「registry data (private, data-only)」へ統一。「Student Data Separation」も registry 語彙に統一
- **docs/PR-REVIEW-GUIDELINES.md / .github/scripts/build-dashboard.sh**: 分離前の「thesis-student-registry 内で `cd registry_manager && mix escript.build`」手順を、独立リポジトリ smkwlab/registry-manager の clone + build 手順に更新。進捗・保護状況の監視は thesis-monitor を案内

検証: `bash -n .github/scripts/build-dashboard.sh` OK、旧用語（`registry_manager` パス・「registry & monitoring」・「student repository list」等）の tracked ファイル残存ゼロ（ECOSYSTEM.md 内の「使わない語の例示」を除く）。

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp