### PR TITLE
docs: document organization-scoped deployment as a management principle

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -126,7 +126,10 @@ deployment identity lives in the organization, never in the code.
   `<org>/thesis-student-registry`. The organization is always derived from
   the runtime context — `github.repository_owner` in GitHub Actions,
   `ORGANIZATION` in create-repo scripts, `github_org` in tool configs.
-  Code must not contain a literal organization name as the effective default.
+  Code must not contain a literal organization name as the effective default —
+  that is, as a value the tools actually fall back to at runtime. Literals in
+  test fixtures, documentation samples, and a clearly-marked local-only
+  fallback (where no runtime context exists) are acceptable.
 - **Deviation by configuration**: deployments that depart from the
   convention override it per deployment — the org-level Actions variable
   `REGISTRY_REPO` for automation, and per-tool overrides
@@ -136,8 +139,9 @@ deployment identity lives in the organization, never in the code.
   Committing a deployment's identity into a tool repository is therefore
   not allowed (it would force forks to diverge).
 - Local tool configs (`~/.config/registry-manager/config.json`,
-  `~/.thesis-monitor.yml`) are caches of this decision plus machine-local
-  details (checkout paths); the org context remains the source of truth.
+  `~/.thesis-monitor.yml`) are a local record of this decision plus
+  machine-local details (checkout paths); the org context remains the
+  source of truth.
 
 ## Template Specialization
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -115,6 +115,30 @@ Supporting Infrastructure:
 - Automated suggestion workflows
 - Minimal manual intervention required
 
+### 5. **Organization-Scoped Deployment**
+
+The ecosystem operates **per GitHub organization**: one organization is one
+deployment unit, holding its own registry data repository, student
+repositories, and automation. The tools are distributed as code; the
+deployment identity lives in the organization, never in the code.
+
+- **Location by convention**: the registry data repository is
+  `<org>/thesis-student-registry`. The organization is always derived from
+  the runtime context — `github.repository_owner` in GitHub Actions,
+  `ORGANIZATION` in create-repo scripts, `github_org` in tool configs.
+  Code must not contain a literal organization name as the effective default.
+- **Deviation by configuration**: deployments that depart from the
+  convention override it per deployment — the org-level Actions variable
+  `REGISTRY_REPO` for automation, and per-tool overrides
+  (`--registry-repo` flag / environment variable / local config) for CLIs.
+- **Fork-clean guarantee**: cloning or forking the tool repositories into
+  another organization must work **without editing distributed code**.
+  Committing a deployment's identity into a tool repository is therefore
+  not allowed (it would force forks to diverge).
+- Local tool configs (`~/.config/registry-manager/config.json`,
+  `~/.thesis-monitor.yml`) are caches of this decision plus machine-local
+  details (checkout paths); the org context remains the source of truth.
+
 ## Template Specialization
 
 ### Document Format Focus


### PR DESCRIPTION
## 概要

registry 所在の決定・伝播に関する設計議論の結論を ECOSYSTEM.md に明文化する。本ツール群が **GitHub organization 単位での運用を前提とする**ことを Management Principles の第 5 原則として記録する。

## 変更内容

- **ECOSYSTEM.md**: Management Principles に「5. Organization-Scoped Deployment」を新設
  - 1 org = 1 デプロイ単位（registry・学生 repo・自動化を org が保有）。デプロイの識別子はコードではなく org 側に属する
  - **規約による所在解決**: registry データリポジトリは `<org>/thesis-student-registry`。org は実行文脈（Actions の `github.repository_owner` / create-repo の `ORGANIZATION` / ツール config の `github_org`）から導出し、コードに org 名リテラルを実効デフォルトとして書かない
  - **規約からの逸脱は設定で**: org-level Actions variable `REGISTRY_REPO`、CLI は `--registry-repo` / env / local config
  - **fork-clean 保証**: 他 org が clone/fork しただけでコード無改変で動くこと。デプロイ識別子のコミット（committed config 案）は fork drift を強いるため禁止
  - local config（registry-manager / thesis-monitor）は「この決定のキャッシュ + マシンローカル事情」と位置づけ

実装側の追従（ハードコード除去と規約デフォルト化）は smkwlab/thesis-management-tools#474 が対応する。

https://claude.ai/code/session_016vdeLgLyz9q2KqHpqwKrBp