### PR TITLE
feat: auto-discover ecosystem repositories instead of hardcoding them

### DIFF
--- a/ecosystem_manager/README.md
+++ b/ecosystem_manager/README.md
@@ -146,6 +146,9 @@ config :ecosystem_manager,
 
 `repos --sync` は検出結果を `~/.config/ecosystem-manager/config.exs` の
 `repositories:` に書き込みます（`workspace_path` など既存の設定は保持）。
+`workspace_path` が未設定なら、検出に使った workspace パスを併せて記録するため、
+workspace ルートで一度 `repos --sync` すれば、どのディレクトリからでも使える
+config.exs がそのまま出来上がります。
 エコシステム外のリポジトリ（無関係なプロジェクト等）が混じっている場合は、
 書き出された一覧から手動で削除してください。新しいリポジトリを workspace に
 追加したら `repos --sync` を再実行するか、`repositories:` を設定から外して

--- a/ecosystem_manager/README.md
+++ b/ecosystem_manager/README.md
@@ -128,33 +128,28 @@ config :ecosystem_manager,
 
 ### リポジトリ設定
 
-監視対象のリポジトリは、ユーザー設定ファイルで指定できます：
+監視対象のリポジトリは **workspace 直下から自動検出** されます。ハードコードされた
+一覧は持たず、以下の順で解決します：
+
+1. ユーザー設定の `repositories:`（明示指定があれば最優先）
+2. 自動検出：workspace 直下の Git リポジトリのうち、エコシステム org
+   （`ecosystem_org:` 設定、無ければ workspace 自身の `origin` owner から導出）
+   に属するもの。`.`（workspace 自身）は常に含み、`*-test` は除外
 
 ```bash
-# 設定ファイル初期化
-./ecosystem-manager init-config
-
-# 現在の設定確認
+# 現在の対象リポジトリと解決元を確認
 ./ecosystem-manager repos
 
-# 設定ファイル編集
-$EDITOR ~/.config/ecosystem-manager/repositories.txt
+# 自動検出結果をユーザー設定に書き出す（一覧を固定したい場合）
+./ecosystem-manager repos --sync
 ```
 
-**設定ファイルの場所（優先順）**:
-1. `~/.config/ecosystem-manager/repositories.txt` (推奨)
-2. `~/.ecosystem-manager-repositories`
-3. `~/.ecosystem-repositories.txt`
-4. `./.ecosystem-repositories` (プロジェクト固有)
-
-**設定ファイル例**:
-```bash
-# コメント行
-.
-texlive-ja-textlint
-latex-environment
-my-custom-template
-```
+`repos --sync` は検出結果を `~/.config/ecosystem-manager/config.exs` の
+`repositories:` に書き込みます（`workspace_path` など既存の設定は保持）。
+エコシステム外のリポジトリ（無関係なプロジェクト等）が混じっている場合は、
+書き出された一覧から手動で削除してください。新しいリポジトリを workspace に
+追加したら `repos --sync` を再実行するか、`repositories:` を設定から外して
+自動検出に任せます。
 
 ## アーキテクチャ
 

--- a/ecosystem_manager/config/config.exs
+++ b/ecosystem_manager/config/config.exs
@@ -36,5 +36,10 @@ config :ecosystem_manager,
   # Workspace path (can be overridden by user config)
   workspace_path: nil,
 
-  # Repository list (can be overridden by user config)
-  repositories: nil
+  # Repository list (can be overridden by user config).
+  # When nil, repositories are auto-discovered under the workspace.
+  repositories: nil,
+
+  # Ecosystem organization used to filter auto-discovered repositories.
+  # When nil, discovery infers it from the workspace's own origin remote.
+  ecosystem_org: nil

--- a/ecosystem_manager/lib/ecosystem_manager/cli.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/cli.ex
@@ -25,7 +25,8 @@ defmodule EcosystemManager.CLI do
           with_prs: :boolean,
           needs_review: :boolean,
           max_concurrency: :integer,
-          time_sort: :boolean
+          time_sort: :boolean,
+          sync: :boolean
         ],
         aliases: [
           h: :help,
@@ -68,8 +69,12 @@ defmodule EcosystemManager.CLI do
     show_config()
   end
 
-  defp continue_execute(%{command: "repos"}) do
-    show_repositories()
+  defp continue_execute(%{command: "repos", opts: opts, base_path: base_path}) do
+    if opts[:sync] do
+      sync_repositories(base_path)
+    else
+      show_repositories(base_path)
+    end
   end
 
   defp continue_execute(%{command: "init-config"}) do
@@ -179,6 +184,8 @@ defmodule EcosystemManager.CLI do
         status          Show status of all repositories (default)
         config          Show current configuration
         repos           Show repository configuration and sources
+        repos --sync    Auto-discover ecosystem repositories and write the
+                        list into the user config (~/.config/ecosystem-manager/config.exs)
         workspace       Show workspace path (useful for: cd $(ecosystem-manager workspace))
         init-config     Create example user configuration files
         help            Show this help message
@@ -223,12 +230,12 @@ defmodule EcosystemManager.CLI do
     IO.puts("Example file: config/config.example.exs")
   end
 
-  defp show_repositories do
+  defp show_repositories(base_path) do
     IO.puts("Repository Configuration")
     IO.puts("=======================")
 
     # Show current repositories
-    repos = Repository.all_repositories()
+    repos = Repository.all_repositories(base_path)
     configured_repos = Repository.get_configured_repositories()
 
     IO.puts("\nMonitored repositories (#{length(repos)}):")
@@ -241,27 +248,37 @@ defmodule EcosystemManager.CLI do
     IO.puts("\nConfiguration source:")
     config_path = UserConfig.get_config_path()
 
-    if File.exists?(config_path) do
-      if configured_repos do
+    cond do
+      configured_repos ->
         IO.puts("  ✓ Using repositories from: #{config_path}")
-      else
-        IO.puts("  ✓ Config file exists: #{config_path}")
-        IO.puts("    (repositories not configured, using defaults)")
-      end
-    else
-      IO.puts("  - No config file: #{config_path}")
-      IO.puts("    (using default repositories)")
+
+      File.exists?(config_path) ->
+        IO.puts("  ✓ Config file exists but has no repositories list: #{config_path}")
+        IO.puts("    (auto-discovered under #{base_path})")
+
+      true ->
+        IO.puts("  - No config file: #{config_path}")
+        IO.puts("    (auto-discovered under #{base_path})")
     end
 
-    # Show defaults
-    defaults = Repository.default_repositories()
-    IO.puts("\nDefault repositories (#{length(defaults)}):")
-    IO.puts("  (used when repositories not configured)")
+    IO.puts("\nTo pin this list into your user config:")
+    IO.puts("  ecosystem-manager repos --sync")
+  end
 
-    IO.puts("\nTo customize:")
-    IO.puts("  1. Run: ecosystem-manager init-config")
-    IO.puts("  2. Edit: ~/.config/ecosystem-manager/config.exs")
-    IO.puts("  3. Add repositories: [...] to the configuration")
+  defp sync_repositories(base_path) do
+    repos = Repository.discover(base_path)
+
+    case UserConfig.set_repositories(repos) do
+      {:ok, path} ->
+        IO.puts("✓ Wrote #{length(repos)} repositories to #{path}\n")
+        Enum.each(repos, fn repo -> IO.puts("  - #{repo}") end)
+        IO.puts("\nReview the list and remove any entries that are not part of the")
+        IO.puts("ecosystem (unrelated projects, one-off clones, etc.).")
+
+      {:error, reason} ->
+        IO.puts("✗ Failed to write repositories to config: #{reason}")
+        exit({:shutdown, 1})
+    end
   end
 
   defp init_config do

--- a/ecosystem_manager/lib/ecosystem_manager/cli.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/cli.ex
@@ -268,9 +268,10 @@ defmodule EcosystemManager.CLI do
   defp sync_repositories(base_path) do
     repos = Repository.discover(base_path)
 
-    case UserConfig.set_repositories(repos) do
+    case UserConfig.set_repositories(repos, default_workspace_path: base_path) do
       {:ok, path} ->
-        IO.puts("✓ Wrote #{length(repos)} repositories to #{path}\n")
+        IO.puts("✓ Wrote #{length(repos)} repositories to #{path}")
+        IO.puts("  workspace_path: #{base_path}\n")
         Enum.each(repos, fn repo -> IO.puts("  - #{repo}") end)
         IO.puts("\nReview the list and remove any entries that are not part of the")
         IO.puts("ecosystem (unrelated projects, one-off clones, etc.).")

--- a/ecosystem_manager/lib/ecosystem_manager/config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/config.ex
@@ -85,6 +85,14 @@ defmodule EcosystemManager.Config do
   end
 
   @doc """
+  Get the ecosystem organization used to filter auto-discovered repositories.
+  Returns nil if not configured (discovery then infers it from the workspace).
+  """
+  def ecosystem_org do
+    Application.get_env(:ecosystem_manager, :ecosystem_org)
+  end
+
+  @doc """
   Get all configuration as a keyword list.
   """
   def all do
@@ -99,7 +107,8 @@ defmodule EcosystemManager.Config do
       github_api_base_url: github_api_base_url(),
       default_include_github: default_include_github(),
       workspace_path: workspace_path(),
-      repositories: repositories()
+      repositories: repositories(),
+      ecosystem_org: ecosystem_org()
     ]
   end
 end

--- a/ecosystem_manager/lib/ecosystem_manager/repository.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/repository.ex
@@ -29,28 +29,110 @@ defmodule EcosystemManager.Repository do
           status: :ok | :error | :missing
         }
 
-  @default_repositories [
-    ".",
-    "texlive-ja-textlint",
-    "latex-environment",
-    "aldc",
-    "sotsuron-template",
-    "latex-template",
-    "sotsuron-report-template",
-    "wr-template",
-    "ise-report-template",
-    "poster-template",
-    "latex-release-action",
-    "thesis-management-tools",
-    "thesis-student-registry",
-    "ai-academic-paper-reviewer",
-    "ai-reviewer"
-  ]
-
-  @doc "Get list of all repositories with precedence: config > defaults"
-  def all_repositories do
-    get_configured_repositories() || @default_repositories
+  @doc """
+  Get the list of ecosystem repositories with precedence:
+  explicit config (`:repositories`) > auto-discovery under `base_path`.
+  """
+  def all_repositories(base_path) do
+    get_configured_repositories() || discover(base_path)
   end
+
+  @doc """
+  Discover ecosystem repositories under `base_path`.
+
+  Scans the immediate subdirectories of `base_path` for Git repositories and
+  returns their names, always including `"."` for the workspace root itself.
+
+  When the ecosystem organization can be determined (an explicit
+  `:ecosystem_org` config value, otherwise the `origin` owner of `base_path`
+  itself), only subdirectories whose `origin` remote belongs to that
+  organization are included; this keeps unrelated personal clones out of the
+  list. Directories whose name ends in `-test` are treated as test fixtures
+  and excluded.
+  """
+  def discover(base_path) do
+    org = ecosystem_org(base_path)
+
+    discovered =
+      case File.ls(base_path) do
+        {:ok, entries} -> entries
+        {:error, _} -> []
+      end
+      |> Enum.filter(&ecosystem_member?(&1, Path.join(base_path, &1), org))
+      |> Enum.sort()
+
+    ["." | discovered]
+  end
+
+  defp ecosystem_member?(name, path, org) do
+    git_repo?(path) and not test_fixture?(name) and org_match?(path, org)
+  end
+
+  defp git_repo?(path) do
+    File.dir?(path) and File.dir?(Path.join(path, ".git"))
+  end
+
+  defp test_fixture?(name), do: String.ends_with?(name, "-test")
+
+  defp org_match?(_path, nil), do: true
+  defp org_match?(path, org), do: origin_owner(path) == org
+
+  @doc """
+  Determine the ecosystem organization for `base_path`.
+
+  Uses the `:ecosystem_org` config value when set, otherwise falls back to the
+  `origin` remote owner of `base_path` itself. Returns nil when neither is
+  available, in which case discovery applies no organization filter.
+  """
+  def ecosystem_org(base_path) do
+    EcosystemManager.Config.ecosystem_org() || origin_owner(base_path)
+  end
+
+  @doc "Return the owner of a repository's `origin` remote, or nil."
+  def origin_owner(path) do
+    case System.cmd("git", ["-C", path, "remote", "get-url", "origin"], stderr_to_stdout: true) do
+      {url, 0} -> parse_owner(String.trim(url))
+      _ -> nil
+    end
+  rescue
+    # System.cmd raises when git is unavailable or the path is invalid
+    _ -> nil
+  end
+
+  @doc """
+  Parse the owner (organization or user) from a Git remote URL.
+
+  Handles the common GitHub URL shapes and returns nil for anything that does
+  not contain an `owner/repo` pair.
+
+  ## Examples
+
+      iex> EcosystemManager.Repository.parse_owner("git@github.com:smkwlab/aldc.git")
+      "smkwlab"
+
+      iex> EcosystemManager.Repository.parse_owner("https://github.com/smkwlab/aldc.git")
+      "smkwlab"
+
+      iex> EcosystemManager.Repository.parse_owner("ssh://git@github.com/smkwlab/aldc.git")
+      "smkwlab"
+
+      iex> EcosystemManager.Repository.parse_owner("not-a-url")
+      nil
+  """
+  def parse_owner(url) when is_binary(url) do
+    segments =
+      url
+      |> String.replace(~r/\.git\z/, "")
+      |> String.trim_trailing("/")
+      |> String.split(~r{[/:]}, trim: true)
+
+    case Enum.take(segments, -2) do
+      [owner, _repo] -> if owner =~ ~r/\./, do: nil, else: owner
+      _ -> nil
+    end
+  end
+
+  def parse_owner(_), do: nil
 
   @doc "Create a new repository struct"
   def new(name, base_path) do
@@ -62,13 +144,10 @@ defmodule EcosystemManager.Repository do
     }
   end
 
-  @doc "Get configured repositories from application config"
+  @doc "Get configured repositories from application config (nil when unset)"
   def get_configured_repositories do
     EcosystemManager.Config.repositories()
   end
-
-  @doc "Get default repositories list"
-  def default_repositories, do: @default_repositories
 
   @doc "Check if repository exists"
   def exists?(%__MODULE__{path: path}) do

--- a/ecosystem_manager/lib/ecosystem_manager/status.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/status.ex
@@ -12,7 +12,7 @@ defmodule EcosystemManager.Status do
     max_concurrency = Keyword.get(opts, :max_concurrency, Config.default_concurrency())
     include_github = Keyword.get(opts, :include_github, Config.default_include_github())
 
-    Repository.all_repositories()
+    Repository.all_repositories(base_path)
     |> Enum.map(&Repository.new(&1, base_path))
     |> Task.async_stream(&fetch_repository_info(&1, include_github),
       max_concurrency: max_concurrency,

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -173,6 +173,58 @@ defmodule EcosystemManager.UserConfig do
     end
   end
 
+  @doc """
+  Write the given repository list into the user config file's
+  `:repositories` setting, preserving any other existing
+  `:ecosystem_manager` settings (such as `workspace_path`).
+
+  Comments in the existing file are not preserved. Returns `{:ok, path}` on
+  success or `{:error, reason}` if the existing file cannot be read or the new
+  file cannot be written.
+  """
+  def set_repositories(repositories) when is_list(repositories) do
+    config_path = get_config_path()
+
+    with {:ok, existing} <- read_existing_settings(config_path),
+         :ok <- ensure_config_dir(get_config_dir()) do
+      merged = Keyword.put(existing, :repositories, repositories)
+
+      case File.write(config_path, render_config(merged)) do
+        :ok -> {:ok, config_path}
+        {:error, reason} -> {:error, "Failed to write config: #{:file.format_error(reason)}"}
+      end
+    end
+  end
+
+  defp read_existing_settings(config_path) do
+    if File.exists?(config_path) do
+      try do
+        data = Config.Reader.read!(config_path)
+        {:ok, Keyword.new(data[:ecosystem_manager] || [])}
+      rescue
+        e -> {:error, "Invalid existing configuration file: #{Exception.message(e)}"}
+      end
+    else
+      {:ok, []}
+    end
+  end
+
+  defp render_config(settings) do
+    body =
+      Enum.map_join(settings, ",\n", fn {key, value} ->
+        "  #{key}: #{inspect(value, limit: :infinity)}"
+      end)
+
+    """
+    # EcosystemManager User Configuration
+    # The repositories list is managed by `ecosystem-manager repos --sync`.
+
+    import Config
+
+    config :ecosystem_manager,
+    """ <> body <> "\n"
+  end
+
   defp ensure_config_dir(config_dir) do
     case File.mkdir_p(config_dir) do
       :ok -> :ok

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -178,21 +178,41 @@ defmodule EcosystemManager.UserConfig do
   `:repositories` setting, preserving any other existing
   `:ecosystem_manager` settings (such as `workspace_path`).
 
+  Options:
+
+    * `:default_workspace_path` - when set and the existing config has no
+      `:workspace_path`, this value is recorded as `workspace_path` so a fresh
+      config generated from the workspace root is immediately usable from any
+      directory. An existing `:workspace_path` is never overwritten.
+
   Comments in the existing file are not preserved. Returns `{:ok, path}` on
   success or `{:error, reason}` if the existing file cannot be read or the new
   file cannot be written.
   """
-  def set_repositories(repositories) when is_list(repositories) do
+  def set_repositories(repositories, opts \\ []) when is_list(repositories) do
     config_path = get_config_path()
 
     with {:ok, existing} <- read_existing_settings(config_path),
          :ok <- ensure_config_dir(get_config_dir()) do
-      merged = Keyword.put(existing, :repositories, repositories)
+      merged =
+        existing
+        |> maybe_put_workspace_path(opts[:default_workspace_path])
+        |> Keyword.put(:repositories, repositories)
 
       case File.write(config_path, render_config(merged)) do
         :ok -> {:ok, config_path}
         {:error, reason} -> {:error, "Failed to write config: #{:file.format_error(reason)}"}
       end
+    end
+  end
+
+  defp maybe_put_workspace_path(settings, nil), do: settings
+
+  defp maybe_put_workspace_path(settings, path) do
+    if Keyword.has_key?(settings, :workspace_path) do
+      settings
+    else
+      Keyword.put(settings, :workspace_path, path)
     end
   end
 

--- a/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
@@ -1,58 +1,167 @@
 defmodule EcosystemManager.RepositoryConfigTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias EcosystemManager.Repository
 
-  describe "repository configuration" do
-    test "default_repositories/0 returns the built-in list" do
-      defaults = Repository.default_repositories()
-      assert is_list(defaults)
-      assert "." in defaults
-      assert "texlive-ja-textlint" in defaults
-      assert length(defaults) > 5
+  # Create a git repository at `path` with an optional `origin` remote.
+  defp init_repo(path, origin \\ nil) do
+    File.mkdir_p!(path)
+    System.cmd("git", ["init"], cd: path, stderr_to_stdout: true)
+
+    if origin do
+      System.cmd("git", ["remote", "add", "origin", origin], cd: path, stderr_to_stdout: true)
     end
 
-    test "default_repositories/0 includes all ecosystem template repositories" do
-      defaults = Repository.default_repositories()
+    path
+  end
 
-      for template <- [
-            "sotsuron-template",
-            "latex-template",
-            "sotsuron-report-template",
-            "wr-template",
-            "ise-report-template",
-            "poster-template"
-          ] do
-        assert template in defaults
-      end
+  defp with_temp_workspace(fun) do
+    temp_dir = System.tmp_dir!()
+    workspace = Path.join(temp_dir, "ws_#{:rand.uniform(1_000_000)}")
+    File.mkdir_p!(workspace)
+
+    original_repos = Application.get_env(:ecosystem_manager, :repositories)
+    original_org = Application.get_env(:ecosystem_manager, :ecosystem_org)
+    Application.delete_env(:ecosystem_manager, :repositories)
+    Application.delete_env(:ecosystem_manager, :ecosystem_org)
+
+    try do
+      fun.(workspace)
+    after
+      restore_env(:repositories, original_repos)
+      restore_env(:ecosystem_org, original_org)
+      File.rm_rf!(workspace)
+    end
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
+  describe "parse_owner/1" do
+    test "parses ssh, https and ssh:// GitHub URLs" do
+      assert Repository.parse_owner("git@github.com:smkwlab/aldc.git") == "smkwlab"
+      assert Repository.parse_owner("https://github.com/smkwlab/aldc.git") == "smkwlab"
+      assert Repository.parse_owner("ssh://git@github.com/smkwlab/aldc.git") == "smkwlab"
+      assert Repository.parse_owner("git@github.com:smkwlab/aldc") == "smkwlab"
     end
 
-    test "get_configured_repositories/0 returns config value" do
+    test "returns nil for URLs without an owner/repo pair" do
+      assert Repository.parse_owner("not-a-url") == nil
+      assert Repository.parse_owner("") == nil
+      assert Repository.parse_owner(nil) == nil
+    end
+  end
+
+  describe "discover/1" do
+    test "always includes the workspace root itself" do
+      with_temp_workspace(fn ws ->
+        assert "." in Repository.discover(ws)
+      end)
+    end
+
+    test "includes git-repo children and excludes non-git directories" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+        File.mkdir_p!(Path.join(ws, "plain-dir"))
+
+        repos = Repository.discover(ws)
+        assert "aldc" in repos
+        refute "plain-dir" in repos
+      end)
+    end
+
+    test "excludes directories whose name ends in -test" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+        init_repo(Path.join(ws, "something-test"))
+
+        repos = Repository.discover(ws)
+        assert "aldc" in repos
+        refute "something-test" in repos
+      end)
+    end
+
+    test "filters by ecosystem org when the workspace has an origin owner" do
+      with_temp_workspace(fn ws ->
+        init_repo(ws, "git@github.com:smkwlab/latex-ecosystem.git")
+        init_repo(Path.join(ws, "aldc"), "git@github.com:smkwlab/aldc.git")
+        init_repo(Path.join(ws, "foreign"), "git@github.com:someone-else/foreign.git")
+
+        repos = Repository.discover(ws)
+        assert "aldc" in repos
+        refute "foreign" in repos
+      end)
+    end
+
+    test "applies no org filter when the workspace has no origin owner" do
+      with_temp_workspace(fn ws ->
+        # ws itself is not a git repo -> org cannot be inferred
+        init_repo(Path.join(ws, "aldc"), "git@github.com:smkwlab/aldc.git")
+        init_repo(Path.join(ws, "foreign"), "git@github.com:someone-else/foreign.git")
+
+        repos = Repository.discover(ws)
+        assert "aldc" in repos
+        assert "foreign" in repos
+      end)
+    end
+
+    test "honors an explicit :ecosystem_org config value" do
+      with_temp_workspace(fn ws ->
+        Application.put_env(:ecosystem_manager, :ecosystem_org, "smkwlab")
+        init_repo(Path.join(ws, "aldc"), "git@github.com:smkwlab/aldc.git")
+        init_repo(Path.join(ws, "foreign"), "git@github.com:someone-else/foreign.git")
+
+        repos = Repository.discover(ws)
+        assert "aldc" in repos
+        refute "foreign" in repos
+      end)
+    end
+
+    test "returns a sorted, deterministic list" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "wr-template"))
+        init_repo(Path.join(ws, "aldc"))
+        init_repo(Path.join(ws, "sotsuron-template"))
+
+        repos = Repository.discover(ws)
+        assert repos == Repository.discover(ws)
+        # "." is always first, the rest are alphabetically sorted
+        assert hd(repos) == "."
+        assert tl(repos) == Enum.sort(tl(repos))
+      end)
+    end
+  end
+
+  describe "all_repositories/1" do
+    test "returns explicit configuration when set" do
+      with_temp_workspace(fn ws ->
+        Application.put_env(:ecosystem_manager, :repositories, ["custom-a", "custom-b"])
+        assert Repository.all_repositories(ws) == ["custom-a", "custom-b"]
+      end)
+    end
+
+    test "falls back to discovery when repositories are not configured" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+
+        repos = Repository.all_repositories(ws)
+        assert "." in repos
+        assert "aldc" in repos
+      end)
+    end
+
+    test "is deterministic" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+        assert Repository.all_repositories(ws) == Repository.all_repositories(ws)
+      end)
+    end
+  end
+
+  describe "get_configured_repositories/0" do
+    test "returns config value (nil or list)" do
       result = Repository.get_configured_repositories()
-      # Should be either nil or a list
       assert is_nil(result) or is_list(result)
-    end
-
-    test "all_repositories/0 falls back to defaults when no config exists" do
-      repos = Repository.all_repositories()
-      assert is_list(repos)
-      assert length(repos) > 0
-    end
-
-    test "all_repositories/0 is deterministic" do
-      repos1 = Repository.all_repositories()
-      repos2 = Repository.all_repositories()
-      assert repos1 == repos2
-    end
-
-    test "default_repositories/0 is stable" do
-      defaults1 = Repository.default_repositories()
-      defaults2 = Repository.default_repositories()
-
-      assert defaults1 == defaults2
-      assert is_list(defaults1)
-      assert "." in defaults1
-      assert length(defaults1) > 0
     end
   end
 end

--- a/ecosystem_manager/test/ecosystem_manager_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager_test.exs
@@ -4,6 +4,23 @@ defmodule EcosystemManagerTest do
 
   alias EcosystemManager.Repository
 
+  # Clear config that the application loads from the developer's real user
+  # config at boot, so discovery-based tests do not depend on the host machine.
+  setup do
+    original_repos = Application.get_env(:ecosystem_manager, :repositories)
+    original_org = Application.get_env(:ecosystem_manager, :ecosystem_org)
+    Application.delete_env(:ecosystem_manager, :repositories)
+    Application.delete_env(:ecosystem_manager, :ecosystem_org)
+
+    on_exit(fn ->
+      restore_env(:repositories, original_repos)
+      restore_env(:ecosystem_org, original_org)
+    end)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
   describe "status/1" do
     test "returns repository list with basic configuration" do
       temp_dir = System.tmp_dir!()

--- a/ecosystem_manager/test/ecosystem_manager_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager_test.exs
@@ -6,14 +6,24 @@ defmodule EcosystemManagerTest do
 
   describe "status/1" do
     test "returns repository list with basic configuration" do
-      repos = EcosystemManager.status(include_github: false)
-      assert is_list(repos)
-      assert length(repos) > 0
+      temp_dir = System.tmp_dir!()
+      workspace = Path.join(temp_dir, "status_basic_#{:rand.uniform(100_000)}")
+      repo_path = Path.join(workspace, "texlive-ja-textlint")
+      File.mkdir_p!(repo_path)
+      System.cmd("git", ["init"], cd: repo_path)
 
-      # Check that we have expected repositories
-      repo_names = Enum.map(repos, & &1.name)
-      assert "." in repo_names
-      assert "texlive-ja-textlint" in repo_names
+      try do
+        repos = EcosystemManager.status(base_path: workspace, include_github: false)
+        assert is_list(repos)
+        assert length(repos) > 0
+
+        # Check that we discovered the workspace root and the child repository
+        repo_names = Enum.map(repos, & &1.name)
+        assert "." in repo_names
+        assert "texlive-ja-textlint" in repo_names
+      after
+        File.rm_rf!(workspace)
+      end
     end
 
     test "accepts base_path option" do

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -168,13 +168,23 @@ defmodule EcosystemManager.RepositoryTest do
   end
 
   describe "all_repositories function" do
-    test "returns list of known repositories" do
-      repos = Repository.all_repositories()
-      assert is_list(repos)
-      assert length(repos) > 0
-      assert "." in repos
-      assert "latex-environment" in repos
-      assert "sotsuron-template" in repos
+    test "discovers git repositories under the workspace" do
+      temp_dir = System.tmp_dir!()
+      workspace = Path.join(temp_dir, "all_repos_#{:rand.uniform(100_000)}")
+      File.mkdir_p!(Path.join(workspace, "latex-environment"))
+      System.cmd("git", ["init"], cd: Path.join(workspace, "latex-environment"))
+      File.mkdir_p!(Path.join(workspace, "sotsuron-template"))
+      System.cmd("git", ["init"], cd: Path.join(workspace, "sotsuron-template"))
+
+      try do
+        repos = Repository.all_repositories(workspace)
+        assert is_list(repos)
+        assert "." in repos
+        assert "latex-environment" in repos
+        assert "sotsuron-template" in repos
+      after
+        File.rm_rf!(workspace)
+      end
     end
   end
 
@@ -259,29 +269,32 @@ defmodule EcosystemManager.RepositoryTest do
     end
 
     test "all_repositories function consistency" do
-      repos1 = Repository.all_repositories()
-      repos2 = Repository.all_repositories()
+      temp_dir = System.tmp_dir!()
+      workspace = Path.join(temp_dir, "consistency_#{:rand.uniform(100_000)}")
 
-      # Should be consistent across calls
-      assert repos1 == repos2
-
-      # Should contain expected core repositories
-      expected_repos = [
-        ".",
-        "texlive-ja-textlint",
-        "latex-environment",
-        "sotsuron-template",
-        "thesis-management-tools"
-      ]
-
-      for expected <- expected_repos do
-        assert expected in repos1
+      for name <- ["texlive-ja-textlint", "latex-environment", "sotsuron-template"] do
+        repo_path = Path.join(workspace, name)
+        File.mkdir_p!(repo_path)
+        System.cmd("git", ["init"], cd: repo_path)
       end
 
-      # Should be a reasonable number of repositories (generous upper bound
-      # so the test does not break as the ecosystem grows)
-      assert length(repos1) > 5
-      assert length(repos1) < 50
+      try do
+        repos1 = Repository.all_repositories(workspace)
+        repos2 = Repository.all_repositories(workspace)
+
+        # Should be consistent across calls
+        assert repos1 == repos2
+
+        # Should contain the workspace root plus discovered repositories
+        assert "." in repos1
+        assert "latex-environment" in repos1
+        assert "sotsuron-template" in repos1
+
+        # "." plus the three created repositories
+        assert length(repos1) == 4
+      after
+        File.rm_rf!(workspace)
+      end
     end
   end
 

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -4,6 +4,24 @@ defmodule EcosystemManager.RepositoryTest do
 
   alias EcosystemManager.Repository
 
+  # The application loads the developer's real user config at boot, which may
+  # set :repositories / :ecosystem_org. Clear them so discovery-based tests do
+  # not depend on the host machine's configuration.
+  setup do
+    original_repos = Application.get_env(:ecosystem_manager, :repositories)
+    original_org = Application.get_env(:ecosystem_manager, :ecosystem_org)
+    Application.delete_env(:ecosystem_manager, :repositories)
+    Application.delete_env(:ecosystem_manager, :ecosystem_org)
+
+    on_exit(fn ->
+      restore_env(:repositories, original_repos)
+      restore_env(:ecosystem_org, original_org)
+    end)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
   describe "new function" do
     test "creates repository struct for current directory" do
       repo = Repository.new(".", "/test/path")

--- a/ecosystem_manager/test/status_test.exs
+++ b/ecosystem_manager/test/status_test.exs
@@ -4,6 +4,23 @@ defmodule EcosystemManager.StatusTest do
 
   alias EcosystemManager.{Repository, Status}
 
+  # Clear config that the application loads from the developer's real user
+  # config at boot, so discovery-based tests do not depend on the host machine.
+  setup do
+    original_repos = Application.get_env(:ecosystem_manager, :repositories)
+    original_org = Application.get_env(:ecosystem_manager, :ecosystem_org)
+    Application.delete_env(:ecosystem_manager, :repositories)
+    Application.delete_env(:ecosystem_manager, :ecosystem_org)
+
+    on_exit(fn ->
+      restore_env(:repositories, original_repos)
+      restore_env(:ecosystem_org, original_org)
+    end)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
   describe "get_all_status function" do
     test "gets status for current directory" do
       base_path = File.cwd!()

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -367,5 +367,39 @@ defmodule EcosystemManager.UserConfigTest do
         assert message =~ "configuration"
       end)
     end
+
+    test "seeds workspace_path from :default_workspace_path when config is fresh" do
+      with_temp_config_dir(fn _config_dir ->
+        assert {:ok, _path} =
+                 UserConfig.set_repositories([".", "aldc"],
+                   default_workspace_path: "/detected/workspace"
+                 )
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspace_path) == "/detected/workspace"
+        assert Application.get_env(:ecosystem_manager, :repositories) == [".", "aldc"]
+      end)
+    end
+
+    test "does not override an existing workspace_path" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        config :ecosystem_manager,
+          workspace_path: "/existing/workspace"
+        """)
+
+        assert {:ok, _path} =
+                 UserConfig.set_repositories([".", "aldc"],
+                   default_workspace_path: "/detected/workspace"
+                 )
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspace_path) == "/existing/workspace"
+      end)
+    end
   end
 end

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -219,6 +219,9 @@ defmodule EcosystemManager.UserConfigTest do
     end
   end
 
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
   # Runs `fun` with ECOSYSTEM_MANAGER_CONFIG_DIR pointing at a fresh
   # temporary directory so UserConfig never touches the developer's real
   # ~/.config/ecosystem-manager. Overriding HOME does not work for this:
@@ -292,6 +295,76 @@ defmodule EcosystemManager.UserConfigTest do
           {:ok, _} ->
             flunk("Expected error when config file already exists")
         end
+      end)
+    end
+  end
+
+  describe "set_repositories/1" do
+    setup do
+      # set_repositories + load/0 mutate the global application env; snapshot
+      # and restore it so these tests do not leak into other test files.
+      original_workspace = Application.get_env(:ecosystem_manager, :workspace_path)
+      original_repos = Application.get_env(:ecosystem_manager, :repositories)
+
+      on_exit(fn ->
+        restore_env(:workspace_path, original_workspace)
+        restore_env(:repositories, original_repos)
+      end)
+    end
+
+    test "writes a repositories list that reloads correctly" do
+      with_temp_config_dir(fn config_dir ->
+        assert {:ok, config_path} = UserConfig.set_repositories([".", "aldc", "wr-template"])
+        assert config_path == Path.join(config_dir, "config.exs")
+
+        content = File.read!(config_path)
+        assert String.contains?(content, "\nimport Config\n")
+        assert String.contains?(content, "repositories:")
+        assert String.contains?(content, "aldc")
+
+        # The generated file must be valid and round-trip through the loader
+        assert UserConfig.load() == :ok
+
+        assert Application.get_env(:ecosystem_manager, :repositories) == [
+                 ".",
+                 "aldc",
+                 "wr-template"
+               ]
+      end)
+    end
+
+    test "preserves existing settings such as workspace_path" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        config :ecosystem_manager,
+          workspace_path: "/existing/workspace",
+          repositories: ["old-repo"]
+        """)
+
+        assert {:ok, ^config_path} = UserConfig.set_repositories([".", "aldc"])
+
+        content = File.read!(config_path)
+        assert String.contains?(content, ~s(workspace_path: "/existing/workspace"))
+        assert String.contains?(content, "aldc")
+        refute String.contains?(content, "old-repo")
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspace_path) == "/existing/workspace"
+        assert Application.get_env(:ecosystem_manager, :repositories) == [".", "aldc"]
+      end)
+    end
+
+    test "returns an error when the existing config is invalid" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+        File.write!(config_path, "this is not valid elixir {{")
+
+        assert {:error, message} = UserConfig.set_repositories([".", "aldc"])
+        assert message =~ "configuration"
       end)
     end
   end


### PR DESCRIPTION
## 概要

`ecosystem-manager` の対象リポジトリを、ソース内ハードコード一覧から **workspace 自動検出** に置き換えます。

resolve #99

## 問題

対象は `repository.ex` の `@default_repositories`（手動メンテのハードコード）で、実際のエコシステム構成とドリフトしていました:

- `registry-manager` / `thesis-monitor`（独立 repo・CLAUDE.md 記載）が一覧に無く status 対象外
- `ai-reviewer` は一覧にあるが、fork を checkout していない環境では missing 表示

## 対応

- **`Repository.discover/1`**: workspace 直下の Git リポジトリを走査。`.`（workspace 自身）を常に含み、エコシステム org（`:ecosystem_org` 設定、無ければ workspace 自身の `origin` owner から導出）で絞り込み、`*-test` は除外
- **`all_repositories/1`**: 解決順を「明示的 `:repositories` 設定 > 自動検出」に変更。ゼロ設定でも動作
- **`repos --sync` サブコマンド**: 検出結果を user config（`~/.config/ecosystem-manager/config.exs`）の `repositories:` に書き出し（`workspace_path` 等の既存キーは保持）。エコシステム外（`toshi-iot74` 等）は人間がレビューで削除
- `@default_repositories` と `default_repositories/0` を廃止

## 動作確認

- `mix test`: 5 doctests, 157 tests, 0 failures
- `mix credo --strict`: no issues / `mix format --check-formatted`: clean
- 実 workspace に対する `repos --sync`: 17 repos を検出（従来漏れていた `registry-manager` / `thesis-monitor` を含み、`thesis-student-registry-test` は除外、`toshi-iot74` はレビュー対象として表示）。生成 config を再読込し `status --fast` で両 repo が対象化されることを確認