### PR TITLE
feat: support multiple workspaces (cwd auto-select + --workspace)

### DIFF
--- a/ecosystem_manager/README.md
+++ b/ecosystem_manager/README.md
@@ -144,20 +144,55 @@ config :ecosystem_manager,
 ./ecosystem-manager repos --sync
 ```
 
-`repos --sync` は検出結果を `~/.config/ecosystem-manager/config.exs` の
-`repositories:` に書き込みます（`workspace_path` など既存の設定は保持）。
-`workspace_path` が未設定なら、検出に使った workspace パスを併せて記録するため、
-workspace ルートで一度 `repos --sync` すれば、どのディレクトリからでも使える
-config.exs がそのまま出来上がります。
-エコシステム外のリポジトリ（無関係なプロジェクト等）が混じっている場合は、
-書き出された一覧から手動で削除してください。新しいリポジトリを workspace に
-追加したら `repos --sync` を再実行するか、`repositories:` を設定から外して
-自動検出に任せます。
+`repos --sync` は実行した workspace を `~/.config/ecosystem-manager/config.exs`
+の `workspaces:` に登録します（既存の設定は保持）。単一 workspace のときは検出結果を
+`repositories:` にピン留めするので、workspace ルートで一度 `repos --sync` すれば
+そのまま使える設定になります。エコシステム外のリポジトリ（無関係なプロジェクト等）が
+混じっている場合は、書き出された一覧から手動で削除してください。
+
+### 複数 workspace
+
+複数のエコシステム（例 `~/prj/LaTeX/latex-ecosystem` と `~/prj/DNS/ecosystem`）を
+1 つのツールで扱えます。各 workspace のルートで `repos --sync` すると `workspaces:` に
+登録されます：
+
+```elixir
+config :ecosystem_manager,
+  workspaces: [
+    latex: "~/prj/LaTeX/latex-ecosystem",
+    dns:   "~/prj/DNS/ecosystem"
+  ]
+```
+
+workspace は次の順で選択されます：
+
+1. `--workspace NAME`（`-w`）で明示指定
+2. カレントディレクトリを含む workspace（最深一致で自動選択）
+3. 登録が 1 つだけならそれ
+4. どれにも該当しなければカレントディレクトリ
+
+```bash
+# 登録済み workspace の一覧
+./ecosystem-manager workspace --list
+
+# cd した先の workspace が対象になる
+cd ~/prj/DNS/ecosystem && ./ecosystem-manager status
+
+# 名前で明示指定
+./ecosystem-manager status -w dns
+
+# 全 workspace をまとめて表示
+./ecosystem-manager status --all
+```
+
+複数 workspace が登録されている場合、リポジトリ一覧は各 workspace ごとに自動検出で
+解決されます（グローバルな `repositories:` ピンは使われません）。
 
 ## アーキテクチャ
 
 - **CLI**: コマンドライン処理とオプション解析
 - **Config**: 設定管理と環境別設定
+- **Workspace**: 複数 workspace の登録・解決（cwd 自動選択 / --workspace）
 - **Repository**: Git情報取得とリポジトリ管理
 - **GitHub**: GitHub API統合（Issues/PR統計）
 - **Status**: 並列処理とフォーマット出力

--- a/ecosystem_manager/config/config.exs
+++ b/ecosystem_manager/config/config.exs
@@ -33,8 +33,13 @@ config :ecosystem_manager,
   github_api_base_url: "https://api.github.com",
   default_include_github: true,
 
-  # Workspace path (can be overridden by user config)
+  # Workspace path (can be overridden by user config).
+  # Legacy single-workspace setting; superseded by :workspaces when set.
   workspace_path: nil,
+
+  # Named workspaces for multi-workspace support (keyword list name: path).
+  # When nil, the legacy :workspace_path is used instead.
+  workspaces: nil,
 
   # Repository list (can be overridden by user config).
   # When nil, repositories are auto-discovered under the workspace.

--- a/ecosystem_manager/lib/ecosystem_manager/cli.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/cli.ex
@@ -119,7 +119,7 @@ defmodule EcosystemManager.CLI do
         IO.puts("Repository Status Overview")
         IO.puts("(no workspaces configured; showing the current directory)")
         IO.puts("")
-        render_status(System.get_env("PWD") || File.cwd!(), opts)
+        render_status(current_dir(), opts)
 
       workspaces ->
         IO.puts("Repository Status Overview (all workspaces)")
@@ -172,31 +172,33 @@ defmodule EcosystemManager.CLI do
   #                          the single configured workspace, or the current
   #                          directory as a last resort.
   defp resolve_base_path(opts) do
-    current_dir = System.get_env("PWD") || File.cwd!()
+    dir = current_dir()
 
-    case Workspace.resolve(opts[:workspace], current_dir) do
-      {:ok, ws} -> validate_workspace_path(ws.path, current_dir)
+    case Workspace.resolve(opts[:workspace], dir) do
+      {:ok, ws} -> validate_workspace_path(ws.path, dir)
       {:error, reason} -> abort(reason)
-      :none -> current_dir
+      :none -> dir
     end
   end
+
+  defp current_dir, do: System.get_env("PWD") || File.cwd!()
 
   # Base path for `repos --sync`: register the current directory's workspace.
   # With --workspace NAME, re-sync that registered workspace instead. Unlike
   # resolve_base_path/1 there is no single-workspace fallback, so syncing from a
   # new ecosystem registers that ecosystem rather than an existing workspace.
   defp sync_base_path(opts) do
-    current_dir = System.get_env("PWD") || File.cwd!()
+    dir = current_dir()
 
     case opts[:workspace] do
       nil ->
-        case Workspace.containing(current_dir) do
-          nil -> {current_dir, nil}
+        case Workspace.containing(dir) do
+          nil -> {dir, nil}
           ws -> {ws.path, ws.name}
         end
 
       name ->
-        case Workspace.resolve(name, current_dir) do
+        case Workspace.resolve(name, dir) do
           {:ok, ws} -> {ws.path, ws.name}
           {:error, reason} -> abort(reason)
         end
@@ -216,7 +218,7 @@ defmodule EcosystemManager.CLI do
   end
 
   defp abort(message) do
-    IO.puts(message)
+    IO.puts(:stderr, message)
     exit({:shutdown, 1})
   end
 
@@ -320,8 +322,15 @@ defmodule EcosystemManager.CLI do
 
   defp sync_repositories(opts) do
     {base_path, resolved_name} = sync_base_path(opts)
-    repos = Repository.discover(base_path)
     name = opts[:name] || resolved_name || Path.basename(base_path)
+
+    unless Workspace.valid_name?(name) do
+      abort(
+        "Invalid workspace name #{inspect(name)}: use letters, digits, '-' or '_' (pass --name to override)."
+      )
+    end
+
+    repos = Repository.discover(base_path)
 
     case UserConfig.sync_workspace(name, base_path, repos) do
       {:ok, path, count} ->

--- a/ecosystem_manager/lib/ecosystem_manager/cli.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/cli.ex
@@ -7,6 +7,7 @@ defmodule EcosystemManager.CLI do
   alias EcosystemManager.Repository
   alias EcosystemManager.Status
   alias EcosystemManager.UserConfig
+  alias EcosystemManager.Workspace
 
   def main(args) do
     args
@@ -26,13 +27,18 @@ defmodule EcosystemManager.CLI do
           needs_review: :boolean,
           max_concurrency: :integer,
           time_sort: :boolean,
-          sync: :boolean
+          sync: :boolean,
+          workspace: :string,
+          name: :string,
+          all: :boolean,
+          list: :boolean
         ],
         aliases: [
           h: :help,
           l: :long,
           f: :fast,
-          t: :time_sort
+          t: :time_sort,
+          w: :workspace
         ]
       )
 
@@ -45,7 +51,7 @@ defmodule EcosystemManager.CLI do
     %{
       command: command,
       opts: opts,
-      base_path: get_base_path()
+      base_path: resolve_base_path(opts)
     }
   end
 
@@ -71,7 +77,7 @@ defmodule EcosystemManager.CLI do
 
   defp continue_execute(%{command: "repos", opts: opts, base_path: base_path}) do
     if opts[:sync] do
-      sync_repositories(base_path)
+      sync_repositories(opts)
     else
       show_repositories(base_path)
     end
@@ -81,8 +87,12 @@ defmodule EcosystemManager.CLI do
     init_config()
   end
 
-  defp continue_execute(%{command: "workspace"}) do
-    show_workspace_path()
+  defp continue_execute(%{command: "workspace", opts: opts, base_path: base_path}) do
+    if opts[:list] do
+      show_workspace_list()
+    else
+      IO.puts(base_path)
+    end
   end
 
   defp continue_execute(%{command: unknown}) do
@@ -94,10 +104,34 @@ defmodule EcosystemManager.CLI do
   end
 
   defp execute_status(%{opts: opts, base_path: base_path}) do
-    IO.puts("Repository Status Overview")
-    IO.puts("")
+    if opts[:all] do
+      execute_status_all(opts)
+    else
+      IO.puts("Repository Status Overview")
+      IO.puts("")
+      render_status(base_path, opts)
+    end
+  end
 
-    # Configure options
+  defp execute_status_all(opts) do
+    case Workspace.list() do
+      [] ->
+        IO.puts("Repository Status Overview")
+        IO.puts("(no workspaces configured; showing the current directory)")
+        IO.puts("")
+        render_status(System.get_env("PWD") || File.cwd!(), opts)
+
+      workspaces ->
+        IO.puts("Repository Status Overview (all workspaces)")
+
+        Enum.each(workspaces, fn ws ->
+          IO.puts("\n== #{ws.name} (#{ws.path}) ==\n")
+          render_status(ws.path, opts)
+        end)
+    end
+  end
+
+  defp render_status(base_path, opts) do
     status_opts = [
       include_github: !opts[:fast],
       max_concurrency: opts[:max_concurrency] || 8
@@ -109,20 +143,12 @@ defmodule EcosystemManager.CLI do
       time_sort: opts[:time_sort] || false
     ]
 
-    # Show timing information
     start_time = System.monotonic_time(:millisecond)
-
-    # Get status
     repos = Status.get_all_status(base_path, status_opts)
+    elapsed = System.monotonic_time(:millisecond) - start_time
 
-    end_time = System.monotonic_time(:millisecond)
-    elapsed = end_time - start_time
+    IO.puts(Status.format_status(repos, format_opts))
 
-    # Format and display
-    output = Status.format_status(repos, format_opts)
-    IO.puts(output)
-
-    # Show performance info
     if opts[:fast] do
       IO.puts("\n(Fast mode - GitHub API calls skipped)")
     end
@@ -140,37 +166,58 @@ defmodule EcosystemManager.CLI do
   defp maybe_add_filter(filters, true, filter), do: [filter | filters]
   defp maybe_add_filter(filters, _, _), do: filters
 
-  defp get_base_path do
-    # First check if workspace_path is configured
-    case Config.workspace_path() do
+  # Resolve the workspace base path for this invocation:
+  #   --workspace NAME    -> that registered workspace (error if unknown)
+  #   otherwise           -> the workspace containing the current directory,
+  #                          the single configured workspace, or the current
+  #                          directory as a last resort.
+  defp resolve_base_path(opts) do
+    current_dir = System.get_env("PWD") || File.cwd!()
+
+    case Workspace.resolve(opts[:workspace], current_dir) do
+      {:ok, ws} -> validate_workspace_path(ws.path, current_dir)
+      {:error, reason} -> abort(reason)
+      :none -> current_dir
+    end
+  end
+
+  # Base path for `repos --sync`: register the current directory's workspace.
+  # With --workspace NAME, re-sync that registered workspace instead. Unlike
+  # resolve_base_path/1 there is no single-workspace fallback, so syncing from a
+  # new ecosystem registers that ecosystem rather than an existing workspace.
+  defp sync_base_path(opts) do
+    current_dir = System.get_env("PWD") || File.cwd!()
+
+    case opts[:workspace] do
       nil ->
-        # If not configured, fall back to finding ecosystem root
-        current_dir = System.get_env("PWD") || File.cwd!()
-        find_ecosystem_root(current_dir) || current_dir
+        case Workspace.containing(current_dir) do
+          nil -> {current_dir, nil}
+          ws -> {ws.path, ws.name}
+        end
 
-      path ->
-        # Expand home directory if needed
-        expanded_path = Path.expand(path)
-
-        if File.dir?(expanded_path) do
-          expanded_path
-        else
-          IO.puts("Warning: Configured workspace_path does not exist: #{expanded_path}")
-          IO.puts("Falling back to current directory detection.")
-          current_dir = System.get_env("PWD") || File.cwd!()
-          find_ecosystem_root(current_dir) || current_dir
+      name ->
+        case Workspace.resolve(name, current_dir) do
+          {:ok, ws} -> {ws.path, ws.name}
+          {:error, reason} -> abort(reason)
         end
     end
   end
 
-  def find_ecosystem_root(dir) do
-    ecosystem_marker = Path.join(dir, "ecosystem-manager.sh")
+  defp validate_workspace_path(path, current_dir) do
+    expanded = Path.expand(path)
 
-    cond do
-      File.exists?(ecosystem_marker) -> dir
-      dir == "/" -> nil
-      true -> find_ecosystem_root(Path.dirname(dir))
+    if File.dir?(expanded) do
+      expanded
+    else
+      IO.puts("Warning: workspace path does not exist: #{expanded}")
+      IO.puts("Falling back to the current directory.")
+      current_dir
     end
+  end
+
+  defp abort(message) do
+    IO.puts(message)
+    exit({:shutdown, 1})
   end
 
   defp show_help do
@@ -181,28 +228,34 @@ defmodule EcosystemManager.CLI do
         ecosystem-manager [COMMAND] [OPTIONS]
 
     COMMANDS:
-        status          Show status of all repositories (default)
-        config          Show current configuration
-        repos           Show repository configuration and sources
-        repos --sync    Auto-discover ecosystem repositories and write the
-                        list into the user config (~/.config/ecosystem-manager/config.exs)
-        workspace       Show workspace path (useful for: cd $(ecosystem-manager workspace))
-        init-config     Create example user configuration files
-        help            Show this help message
+        status            Show status of all repositories (default)
+        config            Show current configuration
+        repos             Show repository configuration and sources
+        repos --sync      Auto-discover ecosystem repositories, write the list
+                          into the user config and register the workspace
+        workspace         Show the resolved workspace path
+        workspace --list  List all configured workspaces
+        init-config       Create example user configuration files
+        help              Show this help message
 
     STATUS OPTIONS:
         -l, --long             Show detailed status with full information
         -f, --fast             Fast mode - skip GitHub API calls
+        --all                  Show every configured workspace (grouped)
         --urgent-issues        Show only repositories with urgent issues
         --with-prs            Show only repositories with open PRs
         --needs-review        Show only repositories with PRs needing review
         --max-concurrency N   Maximum parallel operations (default: 8)
 
+    WORKSPACE OPTIONS:
+        -w, --workspace NAME   Operate on the named workspace (see workspace --list)
+
     EXAMPLES:
         ecosystem-manager                    # Show compact status
         ecosystem-manager status --long     # Show detailed status
         ecosystem-manager status --fast     # Quick status without GitHub API
-        ecosystem-manager status --urgent-issues  # Filter urgent issues
+        ecosystem-manager status --all      # Status across all workspaces
+        ecosystem-manager status -w dns     # Status of the "dns" workspace
         cd $(ecosystem-manager workspace)   # Change to workspace directory
 
     PERFORMANCE:
@@ -265,21 +318,32 @@ defmodule EcosystemManager.CLI do
     IO.puts("  ecosystem-manager repos --sync")
   end
 
-  defp sync_repositories(base_path) do
+  defp sync_repositories(opts) do
+    {base_path, resolved_name} = sync_base_path(opts)
     repos = Repository.discover(base_path)
+    name = opts[:name] || resolved_name || Path.basename(base_path)
 
-    case UserConfig.set_repositories(repos, default_workspace_path: base_path) do
-      {:ok, path} ->
-        IO.puts("✓ Wrote #{length(repos)} repositories to #{path}")
-        IO.puts("  workspace_path: #{base_path}\n")
+    case UserConfig.sync_workspace(name, base_path, repos) do
+      {:ok, path, count} ->
+        IO.puts("✓ Registered workspace \"#{name}\": #{base_path}")
+        IO.puts("  #{length(repos)} repositories discovered\n")
         Enum.each(repos, fn repo -> IO.puts("  - #{repo}") end)
-        IO.puts("\nReview the list and remove any entries that are not part of the")
-        IO.puts("ecosystem (unrelated projects, one-off clones, etc.).")
+        print_sync_note(count, name)
+        IO.puts("\nConfig: #{path}")
 
       {:error, reason} ->
-        IO.puts("✗ Failed to write repositories to config: #{reason}")
-        exit({:shutdown, 1})
+        abort("Failed to write repositories to config: #{reason}")
     end
+  end
+
+  defp print_sync_note(count, _name) when count > 1 do
+    IO.puts("\n#{count} workspaces are configured. Each workspace's repositories are")
+    IO.puts("auto-discovered, so the global repositories pin was removed.")
+  end
+
+  defp print_sync_note(_count, _name) do
+    IO.puts("\nReview the list and remove any entries that are not part of the")
+    IO.puts("ecosystem (unrelated projects, one-off clones, etc.).")
   end
 
   defp init_config do
@@ -297,8 +361,18 @@ defmodule EcosystemManager.CLI do
     end
   end
 
-  defp show_workspace_path do
-    workspace_path = get_base_path()
-    IO.puts(workspace_path)
+  defp show_workspace_list do
+    case Workspace.list() do
+      [] ->
+        IO.puts("No workspaces configured.")
+        IO.puts("Run 'ecosystem-manager repos --sync' from a workspace to register one.")
+
+      workspaces ->
+        IO.puts("Configured workspaces (#{length(workspaces)}):")
+
+        Enum.each(workspaces, fn ws ->
+          IO.puts("  #{String.pad_trailing(ws.name, 20)} #{ws.path}")
+        end)
+    end
   end
 end

--- a/ecosystem_manager/lib/ecosystem_manager/config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/config.ex
@@ -77,6 +77,16 @@ defmodule EcosystemManager.Config do
   end
 
   @doc """
+  Get the configured list of named workspaces.
+
+  Returns a keyword list (`[name: path, ...]`) or nil if not configured, in
+  which case the legacy single `:workspace_path` is used instead.
+  """
+  def workspaces do
+    Application.get_env(:ecosystem_manager, :workspaces)
+  end
+
+  @doc """
   Get repositories configuration.
   Returns nil if not configured.
   """
@@ -107,6 +117,7 @@ defmodule EcosystemManager.Config do
       github_api_base_url: github_api_base_url(),
       default_include_github: default_include_github(),
       workspace_path: workspace_path(),
+      workspaces: workspaces(),
       repositories: repositories(),
       ecosystem_org: ecosystem_org()
     ]

--- a/ecosystem_manager/lib/ecosystem_manager/repository.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/repository.ex
@@ -32,9 +32,21 @@ defmodule EcosystemManager.Repository do
   @doc """
   Get the list of ecosystem repositories with precedence:
   explicit config (`:repositories`) > auto-discovery under `base_path`.
+
+  The explicit `:repositories` pin is a single global list, so it is only
+  honored when at most one workspace is configured. With multiple workspaces
+  each resolves its own list via discovery under its own `base_path`.
   """
   def all_repositories(base_path) do
-    get_configured_repositories() || discover(base_path)
+    if single_workspace?() do
+      get_configured_repositories() || discover(base_path)
+    else
+      discover(base_path)
+    end
+  end
+
+  defp single_workspace? do
+    length(EcosystemManager.Workspace.list()) <= 1
   end
 
   @doc """

--- a/ecosystem_manager/lib/ecosystem_manager/user_config.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/user_config.ex
@@ -103,11 +103,20 @@ defmodule EcosystemManager.UserConfig do
     # This path will be used as the base directory for all operations
     config :ecosystem_manager,
       workspace_path: "~/SynologyDrive/semi/LaTeX/latex-ecosystem",
-      
-      # Optional: Override default repository list
+
+      # Optional: multiple named workspaces. When set, this supersedes
+      # workspace_path above. The workspace containing your current directory
+      # is selected automatically; pick one explicitly with --workspace NAME.
+      # `ecosystem-manager repos --sync` registers the current workspace here.
+      # workspaces: [
+      #   latex: "~/prj/LaTeX/latex-ecosystem",
+      #   dns:   "~/prj/DNS/ecosystem"
+      # ],
+
+      # Optional: Override default repository list (single-workspace only)
       # repositories: [
       #   ".",
-      #   "texlive-ja-textlint", 
+      #   "texlive-ja-textlint",
       #   "latex-environment",
       #   "sotsuron-template",
       #   "my-custom-repo"
@@ -214,6 +223,56 @@ defmodule EcosystemManager.UserConfig do
     else
       Keyword.put(settings, :workspace_path, path)
     end
+  end
+
+  @doc """
+  Register a workspace and record its discovered repositories.
+
+  The workspace `name` -> `path` is added to (or updated in) `:workspaces`, and
+  the legacy single `:workspace_path` is dropped in favor of it. The discovered
+  `repositories` list is written as the global pin only while a single
+  workspace is configured; once several workspaces exist the pin is removed
+  because each workspace resolves its own list via discovery.
+
+  Returns `{:ok, path, workspace_count}` or `{:error, reason}`.
+  """
+  def sync_workspace(name, path, repositories) do
+    config_path = get_config_path()
+
+    with {:ok, existing} <- read_existing_settings(config_path),
+         :ok <- ensure_config_dir(get_config_dir()) do
+      workspaces = upsert_workspace(existing[:workspaces] || [], String.to_atom(name), path)
+      count = length(workspaces)
+
+      merged =
+        existing
+        |> Keyword.put(:workspaces, workspaces)
+        |> Keyword.delete(:workspace_path)
+        |> put_or_drop_repositories(repositories, count)
+
+      case File.write(config_path, render_config(merged)) do
+        :ok -> {:ok, config_path, count}
+        {:error, reason} -> {:error, "Failed to write config: #{:file.format_error(reason)}"}
+      end
+    end
+  end
+
+  # Update the entry in place when the name already exists (preserving order),
+  # otherwise append it so registration order is stable across syncs.
+  defp upsert_workspace(workspaces, key, path) do
+    if Keyword.has_key?(workspaces, key) do
+      Enum.map(workspaces, fn {k, v} -> {k, if(k == key, do: path, else: v)} end)
+    else
+      workspaces ++ [{key, path}]
+    end
+  end
+
+  defp put_or_drop_repositories(settings, repositories, 1) do
+    Keyword.put(settings, :repositories, repositories)
+  end
+
+  defp put_or_drop_repositories(settings, _repositories, _count) do
+    Keyword.delete(settings, :repositories)
   end
 
   defp read_existing_settings(config_path) do

--- a/ecosystem_manager/lib/ecosystem_manager/workspace.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/workspace.ex
@@ -1,0 +1,120 @@
+defmodule EcosystemManager.Workspace do
+  @moduledoc """
+  Multi-workspace support.
+
+  Resolves which ecosystem workspace a command operates on, from the configured
+  list of workspaces and the current working directory.
+  """
+
+  alias EcosystemManager.Config
+
+  defstruct [:name, :path]
+
+  @type t :: %__MODULE__{name: String.t(), path: String.t()}
+
+  @doc """
+  Return the configured workspaces as a list of `%Workspace{}` with `~`
+  expanded to absolute paths.
+
+  Uses `:workspaces` (a `[name: path]` keyword list) when configured; otherwise
+  falls back to the legacy single `:workspace_path` as one workspace named
+  after its directory. Returns `[]` when neither is configured.
+  """
+  def list do
+    case Config.workspaces() do
+      nil -> legacy_list()
+      [] -> legacy_list()
+      workspaces -> Enum.map(workspaces, &normalize/1)
+    end
+  end
+
+  @doc "Names of the configured workspaces."
+  def names, do: Enum.map(list(), & &1.name)
+
+  @doc """
+  Resolve which workspace a command operates on.
+
+    * an explicit `name` (from `--workspace`) selects that workspace by name
+    * otherwise the workspace containing `cwd` (deepest match) is used
+    * otherwise, when exactly one workspace is configured, that one is used
+    * otherwise `:none` (the caller falls back to the current directory)
+
+  Returns `{:ok, %Workspace{}}`, `{:error, message}` (unknown name) or `:none`.
+  """
+  def resolve(name, cwd) do
+    workspaces = list()
+
+    if is_binary(name) and name != "" do
+      find_by_name(workspaces, name)
+    else
+      resolve_by_cwd(workspaces, cwd)
+    end
+  end
+
+  defp legacy_list do
+    case Config.workspace_path() do
+      nil ->
+        []
+
+      "" ->
+        []
+
+      path ->
+        expanded = Path.expand(path)
+        [%__MODULE__{name: Path.basename(expanded), path: expanded}]
+    end
+  end
+
+  defp normalize({name, path}) do
+    %__MODULE__{name: to_string(name), path: Path.expand(path)}
+  end
+
+  defp find_by_name(workspaces, name) do
+    case Enum.find(workspaces, &(&1.name == name)) do
+      nil -> {:error, unknown_message(workspaces, name)}
+      ws -> {:ok, ws}
+    end
+  end
+
+  @doc """
+  Return the configured workspace that contains `cwd` (deepest match), or nil.
+
+  Unlike `resolve/2`, this applies no single-workspace fallback: it is used by
+  `repos --sync` to register the workspace for the current directory.
+  """
+  def containing(cwd), do: deepest_containing(list(), cwd)
+
+  defp resolve_by_cwd(workspaces, cwd) do
+    case deepest_containing(workspaces, cwd) do
+      nil ->
+        case workspaces do
+          [single] -> {:ok, single}
+          _ -> :none
+        end
+
+      ws ->
+        {:ok, ws}
+    end
+  end
+
+  # Workspace whose path equals cwd or is an ancestor of cwd; deepest wins.
+  defp deepest_containing(workspaces, cwd) do
+    case Enum.filter(workspaces, &contains?(&1.path, cwd)) do
+      [] -> nil
+      matches -> Enum.max_by(matches, &String.length(&1.path))
+    end
+  end
+
+  defp contains?(path, cwd) do
+    cwd == path or String.starts_with?(cwd, path <> "/")
+  end
+
+  defp unknown_message([], name) do
+    "Unknown workspace: #{name}. No workspaces are configured."
+  end
+
+  defp unknown_message(workspaces, name) do
+    registered = Enum.map_join(workspaces, ", ", & &1.name)
+    "Unknown workspace: #{name}. Registered: #{registered}"
+  end
+end

--- a/ecosystem_manager/lib/ecosystem_manager/workspace.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/workspace.ex
@@ -32,6 +32,14 @@ defmodule EcosystemManager.Workspace do
   def names, do: Enum.map(list(), & &1.name)
 
   @doc """
+  Whether `name` is a valid workspace name: 1-64 characters of letters, digits,
+  `-` or `_`. Registration converts the name to an atom for the config keyword
+  list, so the accepted set is bounded to keep it a well-formed identifier.
+  """
+  def valid_name?(name) when is_binary(name), do: name =~ ~r/\A[A-Za-z0-9_-]{1,64}\z/
+  def valid_name?(_), do: false
+
+  @doc """
   Resolve which workspace a command operates on.
 
     * an explicit `name` (from `--workspace`) selects that workspace by name
@@ -47,7 +55,7 @@ defmodule EcosystemManager.Workspace do
     if is_binary(name) and name != "" do
       find_by_name(workspaces, name)
     else
-      resolve_by_cwd(workspaces, cwd)
+      resolve_by_cwd(workspaces, Path.expand(cwd))
     end
   end
 
@@ -82,7 +90,7 @@ defmodule EcosystemManager.Workspace do
   Unlike `resolve/2`, this applies no single-workspace fallback: it is used by
   `repos --sync` to register the workspace for the current directory.
   """
-  def containing(cwd), do: deepest_containing(list(), cwd)
+  def containing(cwd), do: deepest_containing(list(), Path.expand(cwd))
 
   defp resolve_by_cwd(workspaces, cwd) do
     case deepest_containing(workspaces, cwd) do

--- a/ecosystem_manager/test/cli_test.exs
+++ b/ecosystem_manager/test/cli_test.exs
@@ -101,55 +101,10 @@ defmodule EcosystemManager.CLITest do
     end
   end
 
-  describe "find_ecosystem_root/1" do
-    test "finds root with marker file" do
-      temp_dir = System.tmp_dir!()
-      test_dir = Path.join(temp_dir, "test_ecosystem_#{:rand.uniform(10_000)}")
-      File.mkdir_p!(test_dir)
-      marker_file = Path.join(test_dir, "ecosystem-manager.sh")
-      File.write!(marker_file, "#!/bin/bash\necho test")
-
-      try do
-        result = CLI.find_ecosystem_root(test_dir)
-        assert result == test_dir
-      after
-        File.rm_rf!(test_dir)
-      end
-    end
-
-    test "returns nil when no marker found" do
-      temp_dir = System.tmp_dir!()
-      test_dir = Path.join(temp_dir, "no_marker_#{:rand.uniform(10_000)}")
-      File.mkdir_p!(test_dir)
-
-      try do
-        result = CLI.find_ecosystem_root(test_dir)
-        assert result == nil
-      after
-        File.rm_rf!(test_dir)
-      end
-    end
-
-    test "traverses up directory tree" do
-      temp_dir = System.tmp_dir!()
-      deep_path = Path.join(temp_dir, "level1/level2/level3/level4")
-      File.mkdir_p!(deep_path)
-      marker_path = Path.join(temp_dir, "level1/level2")
-      marker_file = Path.join(marker_path, "ecosystem-manager.sh")
-      File.write!(marker_file, "#!/bin/bash\necho test")
-
-      try do
-        result = CLI.find_ecosystem_root(deep_path)
-        assert result == marker_path
-      after
-        File.rm_rf!(Path.join(temp_dir, "level1"))
-      end
-    end
-  end
-
-  describe "get_base_path with workspace_path config" do
-    test "base_path uses find_ecosystem_root when workspace_path not configured" do
-      # With default config (workspace_path: nil), it should use current directory logic
+  describe "base_path resolution" do
+    test "base_path falls back to the current directory when no workspace is configured" do
+      # With default config (no workspaces / workspace_path), resolution should
+      # fall back to the current directory.
       result = CLI.parse_args(["status"])
       assert is_binary(result.base_path)
     end

--- a/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/repository_config_test.exs
@@ -20,16 +20,17 @@ defmodule EcosystemManager.RepositoryConfigTest do
     workspace = Path.join(temp_dir, "ws_#{:rand.uniform(1_000_000)}")
     File.mkdir_p!(workspace)
 
-    original_repos = Application.get_env(:ecosystem_manager, :repositories)
-    original_org = Application.get_env(:ecosystem_manager, :ecosystem_org)
-    Application.delete_env(:ecosystem_manager, :repositories)
-    Application.delete_env(:ecosystem_manager, :ecosystem_org)
+    saved =
+      for key <- [:repositories, :ecosystem_org, :workspaces, :workspace_path] do
+        value = Application.get_env(:ecosystem_manager, key)
+        Application.delete_env(:ecosystem_manager, key)
+        {key, value}
+      end
 
     try do
       fun.(workspace)
     after
-      restore_env(:repositories, original_repos)
-      restore_env(:ecosystem_org, original_org)
+      Enum.each(saved, fn {key, value} -> restore_env(key, value) end)
       File.rm_rf!(workspace)
     end
   end
@@ -154,6 +155,28 @@ defmodule EcosystemManager.RepositoryConfigTest do
       with_temp_workspace(fn ws ->
         init_repo(Path.join(ws, "aldc"))
         assert Repository.all_repositories(ws) == Repository.all_repositories(ws)
+      end)
+    end
+
+    test "honors the global repositories pin with a single configured workspace" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+        Application.put_env(:ecosystem_manager, :repositories, ["pinned-only"])
+        Application.put_env(:ecosystem_manager, :workspaces, only: "/home/u/only")
+
+        assert Repository.all_repositories(ws) == ["pinned-only"]
+      end)
+    end
+
+    test "ignores the global repositories pin when multiple workspaces are configured" do
+      with_temp_workspace(fn ws ->
+        init_repo(Path.join(ws, "aldc"))
+        Application.put_env(:ecosystem_manager, :repositories, ["pinned-only"])
+        Application.put_env(:ecosystem_manager, :workspaces, a: "/home/u/a", b: "/home/u/b")
+
+        repos = Repository.all_repositories(ws)
+        refute "pinned-only" in repos
+        assert "aldc" in repos
       end)
     end
   end

--- a/ecosystem_manager/test/ecosystem_manager/workspace_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/workspace_test.exs
@@ -1,0 +1,147 @@
+defmodule EcosystemManager.WorkspaceTest do
+  use ExUnit.Case, async: false
+
+  alias EcosystemManager.Workspace
+
+  setup do
+    original_workspaces = Application.get_env(:ecosystem_manager, :workspaces)
+    original_workspace_path = Application.get_env(:ecosystem_manager, :workspace_path)
+    Application.delete_env(:ecosystem_manager, :workspaces)
+    Application.delete_env(:ecosystem_manager, :workspace_path)
+
+    on_exit(fn ->
+      restore_env(:workspaces, original_workspaces)
+      restore_env(:workspace_path, original_workspace_path)
+    end)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:ecosystem_manager, key)
+  defp restore_env(key, value), do: Application.put_env(:ecosystem_manager, key, value)
+
+  describe "list/0" do
+    test "returns [] when nothing is configured" do
+      assert Workspace.list() == []
+    end
+
+    test "normalizes the :workspaces keyword list, expanding ~" do
+      Application.put_env(:ecosystem_manager, :workspaces,
+        latex: "/home/u/latex-ecosystem",
+        dns: "~/dns/ecosystem"
+      )
+
+      assert [latex, dns] = Workspace.list()
+      assert latex.name == "latex"
+      assert latex.path == "/home/u/latex-ecosystem"
+      assert dns.name == "dns"
+      assert dns.path == Path.expand("~/dns/ecosystem")
+    end
+
+    test "falls back to legacy workspace_path as a single named workspace" do
+      Application.put_env(:ecosystem_manager, :workspace_path, "/home/u/latex-ecosystem")
+
+      assert [ws] = Workspace.list()
+      assert ws.name == "latex-ecosystem"
+      assert ws.path == "/home/u/latex-ecosystem"
+    end
+
+    test "prefers :workspaces over legacy :workspace_path" do
+      Application.put_env(:ecosystem_manager, :workspace_path, "/home/u/legacy")
+      Application.put_env(:ecosystem_manager, :workspaces, only: "/home/u/only")
+
+      assert [ws] = Workspace.list()
+      assert ws.name == "only"
+      assert ws.path == "/home/u/only"
+    end
+  end
+
+  describe "resolve/2 by name" do
+    setup do
+      Application.put_env(:ecosystem_manager, :workspaces,
+        latex: "/home/u/latex-ecosystem",
+        dns: "/home/u/dns/ecosystem"
+      )
+
+      :ok
+    end
+
+    test "selects a workspace by explicit name regardless of cwd" do
+      assert {:ok, ws} = Workspace.resolve("dns", "/somewhere/else")
+      assert ws.name == "dns"
+    end
+
+    test "returns an error listing registered names for an unknown name" do
+      assert {:error, message} = Workspace.resolve("nope", "/tmp")
+      assert message =~ "Unknown workspace: nope"
+      assert message =~ "latex"
+      assert message =~ "dns"
+    end
+  end
+
+  describe "resolve/2 by cwd" do
+    setup do
+      Application.put_env(:ecosystem_manager, :workspaces,
+        latex: "/home/u/latex-ecosystem",
+        dns: "/home/u/dns/ecosystem"
+      )
+
+      :ok
+    end
+
+    test "selects the workspace that contains cwd" do
+      assert {:ok, ws} = Workspace.resolve(nil, "/home/u/latex-ecosystem/aldc")
+      assert ws.name == "latex"
+    end
+
+    test "matches when cwd equals the workspace path" do
+      assert {:ok, ws} = Workspace.resolve(nil, "/home/u/dns/ecosystem")
+      assert ws.name == "dns"
+    end
+
+    test "returns :none when cwd is outside every workspace and several exist" do
+      assert Workspace.resolve(nil, "/home/u/unrelated") == :none
+    end
+
+    test "does not match a sibling directory sharing a path prefix" do
+      # /home/u/latex-ecosystem must not match /home/u/latex-ecosystem-extra
+      assert Workspace.resolve(nil, "/home/u/latex-ecosystem-extra") == :none
+    end
+  end
+
+  describe "resolve/2 deepest match" do
+    test "prefers the most specific (deepest) containing workspace" do
+      Application.put_env(:ecosystem_manager, :workspaces,
+        outer: "/home/u/prj",
+        inner: "/home/u/prj/latex-ecosystem"
+      )
+
+      assert {:ok, ws} = Workspace.resolve(nil, "/home/u/prj/latex-ecosystem/aldc")
+      assert ws.name == "inner"
+    end
+  end
+
+  describe "resolve/2 single workspace" do
+    test "uses the only workspace even when cwd is outside it" do
+      Application.put_env(:ecosystem_manager, :workspaces, latex: "/home/u/latex-ecosystem")
+
+      assert {:ok, ws} = Workspace.resolve(nil, "/somewhere/else")
+      assert ws.name == "latex"
+    end
+  end
+
+  describe "containing/1" do
+    test "returns the deepest workspace containing cwd" do
+      Application.put_env(:ecosystem_manager, :workspaces,
+        outer: "/home/u/prj",
+        inner: "/home/u/prj/latex-ecosystem"
+      )
+
+      assert %Workspace{name: "inner"} = Workspace.containing("/home/u/prj/latex-ecosystem/aldc")
+    end
+
+    test "returns nil outside every workspace, with no single-workspace fallback" do
+      Application.put_env(:ecosystem_manager, :workspaces, latex: "/home/u/latex-ecosystem")
+
+      assert Workspace.containing("/home/u/dns/ecosystem") == nil
+    end
+  end
+end

--- a/ecosystem_manager/test/ecosystem_manager/workspace_test.exs
+++ b/ecosystem_manager/test/ecosystem_manager/workspace_test.exs
@@ -77,6 +77,23 @@ defmodule EcosystemManager.WorkspaceTest do
     end
   end
 
+  describe "valid_name?/1" do
+    test "accepts identifier-like names" do
+      assert Workspace.valid_name?("latex")
+      assert Workspace.valid_name?("dns")
+      assert Workspace.valid_name?("a-b_c1")
+      assert Workspace.valid_name?(String.duplicate("a", 64))
+    end
+
+    test "rejects empty, whitespace, path separators and overly long names" do
+      refute Workspace.valid_name?("")
+      refute Workspace.valid_name?("my workspace")
+      refute Workspace.valid_name?("a/b")
+      refute Workspace.valid_name?(String.duplicate("a", 65))
+      refute Workspace.valid_name?(nil)
+    end
+  end
+
   describe "resolve/2 by cwd" do
     setup do
       Application.put_env(:ecosystem_manager, :workspaces,
@@ -90,6 +107,11 @@ defmodule EcosystemManager.WorkspaceTest do
     test "selects the workspace that contains cwd" do
       assert {:ok, ws} = Workspace.resolve(nil, "/home/u/latex-ecosystem/aldc")
       assert ws.name == "latex"
+    end
+
+    test "normalizes cwd (trailing slash / relative segments) before matching" do
+      assert {:ok, %{name: "latex"}} = Workspace.resolve(nil, "/home/u/latex-ecosystem/")
+      assert {:ok, %{name: "latex"}} = Workspace.resolve(nil, "/home/u/latex-ecosystem/sub/..")
     end
 
     test "matches when cwd equals the workspace path" do

--- a/ecosystem_manager/test/user_config_test.exs
+++ b/ecosystem_manager/test/user_config_test.exs
@@ -402,4 +402,92 @@ defmodule EcosystemManager.UserConfigTest do
       end)
     end
   end
+
+  describe "sync_workspace/3" do
+    setup do
+      original =
+        for key <- [:workspace_path, :workspaces, :repositories] do
+          {key, Application.get_env(:ecosystem_manager, key)}
+        end
+
+      on_exit(fn ->
+        Enum.each(original, fn {key, value} -> restore_env(key, value) end)
+      end)
+    end
+
+    test "registers the first workspace and pins its discovered repositories" do
+      with_temp_config_dir(fn _config_dir ->
+        assert {:ok, _path, 1} =
+                 UserConfig.sync_workspace("latex", "/home/u/latex", [".", "aldc"])
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspaces) == [latex: "/home/u/latex"]
+        assert Application.get_env(:ecosystem_manager, :repositories) == [".", "aldc"]
+      end)
+    end
+
+    test "migrates a legacy workspace_path away in favor of :workspaces" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        config :ecosystem_manager,
+          workspace_path: "/home/u/latex"
+        """)
+
+        assert {:ok, path, 1} =
+                 UserConfig.sync_workspace("latex", "/home/u/latex", ["."])
+
+        # load/0 never deletes keys already in the application env, so assert on
+        # the generated file: workspace_path must be gone, replaced by :workspaces.
+        content = File.read!(path)
+        refute String.contains?(content, "workspace_path")
+        assert String.contains?(content, "workspaces:")
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspaces) == [latex: "/home/u/latex"]
+      end)
+    end
+
+    test "adds a second workspace and drops the global repositories pin" do
+      with_temp_config_dir(fn config_dir ->
+        config_path = Path.join(config_dir, "config.exs")
+
+        File.write!(config_path, """
+        import Config
+
+        config :ecosystem_manager,
+          workspaces: [latex: "/home/u/latex"],
+          repositories: [".", "aldc"]
+        """)
+
+        assert {:ok, path, 2} =
+                 UserConfig.sync_workspace("dns", "/home/u/dns", [".", "zone"])
+
+        # The global repositories pin must be dropped from the generated file
+        # (load/0 does not delete pre-existing application env keys).
+        content = File.read!(path)
+        refute String.contains?(content, "repositories:")
+
+        assert UserConfig.load() == :ok
+
+        assert Application.get_env(:ecosystem_manager, :workspaces) == [
+                 latex: "/home/u/latex",
+                 dns: "/home/u/dns"
+               ]
+      end)
+    end
+
+    test "updating an existing workspace keeps the count at one" do
+      with_temp_config_dir(fn _config_dir ->
+        assert {:ok, _path, 1} = UserConfig.sync_workspace("latex", "/old/path", ["."])
+        assert {:ok, _path, 1} = UserConfig.sync_workspace("latex", "/new/path", ["."])
+
+        assert UserConfig.load() == :ok
+        assert Application.get_env(:ecosystem_manager, :workspaces) == [latex: "/new/path"]
+      end)
+    end
+  end
 end


### PR DESCRIPTION
## 概要

`ecosystem-manager` を複数 workspace に対応させます。cd した先の workspace を自動選択し、`--workspace NAME` での明示選択も可能にします。

resolve #101

## 問題

- 設定は `workspace_path`（単数）前提で、複数のエコシステム（例 `~/prj/LaTeX/latex-ecosystem` と `~/prj/DNS/ecosystem`）を 1 つのツールで扱えない
- cwd 検出の `find_ecosystem_root` は既に存在しないマーカー `ecosystem-manager.sh` を探しており実質機能していない
- エコシステムルートの共通マーカーは存在しない（LaTeX は `ECOSYSTEM.md`、DNS は `CLAUDE.md` のみ）→ 明示登録 + cwd 照合が妥当

## 対応

- **`Workspace` モジュール** + 名前付き `:workspaces` 設定（keyword list）。legacy `:workspace_path` は無名単一 workspace として後方互換
- **解決順**: `--workspace NAME` → cwd を含む workspace（最深一致）→ 単一 workspace → cwd フォールバック
- **`workspace --list`**: 登録一覧表示 / **`-w, --workspace NAME`**: 明示選択
- **`status --all`**: 全 workspace を集約表示（workspace ごとにグループ）
- **`repos --sync [--name NAME]`**: 実行 cwd の workspace を `workspaces:` に登録（cwd ベース＝単一フォールバック無し。単一 workspace のときは検出結果を `repositories:` にピン留め、複数になるとピンを外し各自動検出）
- **`all_repositories/1`**: 複数 workspace 登録時はグローバル `repositories:` ピンを無視し必ず自動検出（全 workspace が同一リストになる不整合を防止）
- 死んだ `find_ecosystem_root` マーカー探索を撤去

## 動作確認

- `mix test`: 5 doctests, 176 tests, 0 failures / `mix credo --strict`・`mix format --check-formatted`: clean
- escript による e2e:
  - `workspace --list` / `-w dns` 選択 / 未知名は明示エラー
  - cd 先で自動選択（DNS→dns、latex サブディレクトリ→latex 最深一致、範囲外→cwd フォールバック）
  - `status --all --fast` が workspace ごとにグループ表示
  - `repos --sync --name dns` を DNS ルートで実行 → `dns: ~/prj/DNS/ecosystem` が正しく登録され、2 つ目登録でグローバルピンが除去される

## 補足

`repos --sync` の挙動が #100（単一 workspace で `repositories`+`workspace_path` を書く）から変わります: workspace 登録が主となり、`workspace_path` は `workspaces:` に移行、`repositories` ピンは単一 workspace のときのみ維持します。