### PR TITLE
fix: derive the workspace-root display name from its directory

### DIFF
--- a/ecosystem_manager/lib/ecosystem_manager/repository.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/repository.ex
@@ -151,7 +151,7 @@ defmodule EcosystemManager.Repository do
     %__MODULE__{
       name: name,
       path: if(name == ".", do: base_path, else: Path.join(base_path, name)),
-      display_name: get_display_name(name),
+      display_name: display_name(name, base_path),
       status: :ok
     }
   end
@@ -226,6 +226,8 @@ defmodule EcosystemManager.Repository do
 
   # Private functions
 
-  defp get_display_name("."), do: "latex-ecosystem"
-  defp get_display_name(name), do: name
+  # The workspace root ("." ) is shown by its directory name, so each workspace
+  # displays its own name rather than a hardcoded one.
+  defp display_name(".", base_path), do: Path.basename(Path.expand(base_path))
+  defp display_name(name, _base_path), do: name
 end

--- a/ecosystem_manager/lib/ecosystem_manager/repository.ex
+++ b/ecosystem_manager/lib/ecosystem_manager/repository.ex
@@ -227,7 +227,9 @@ defmodule EcosystemManager.Repository do
   # Private functions
 
   # The workspace root ("." ) is shown by its directory name, so each workspace
-  # displays its own name rather than a hardcoded one.
-  defp display_name(".", base_path), do: Path.basename(Path.expand(base_path))
+  # displays its own name rather than a hardcoded one. `base_path` is always an
+  # absolute path from the caller, so `Path.basename/1` is deterministic (no
+  # `Path.expand/1`, which would depend on the current working directory).
+  defp display_name(".", base_path), do: Path.basename(base_path)
   defp display_name(name, _base_path), do: name
 end

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -27,8 +27,14 @@ defmodule EcosystemManager.RepositoryTest do
       repo = Repository.new(".", "/test/path")
       assert repo.name == "."
       assert repo.path == "/test/path"
-      assert repo.display_name == "latex-ecosystem"
+      # "." is the workspace root; its display name is the workspace dir name
+      assert repo.display_name == "path"
       assert repo.status == :ok
+    end
+
+    test "derives the current-directory display name from the workspace path" do
+      assert Repository.new(".", "/home/u/latex-ecosystem").display_name == "latex-ecosystem"
+      assert Repository.new(".", "/home/u/DNS/ecosystem").display_name == "ecosystem"
     end
 
     test "creates repository struct for named directory" do
@@ -208,9 +214,9 @@ defmodule EcosystemManager.RepositoryTest do
 
   describe "display_name function coverage" do
     test "get_display_name through new function" do
-      # Test current directory special case
+      # Test current directory special case: display name is the workspace dir
       current_repo = Repository.new(".", "/test/path")
-      assert current_repo.display_name == "latex-ecosystem"
+      assert current_repo.display_name == "path"
 
       # Test regular repository names
       regular_names = [

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -37,6 +37,11 @@ defmodule EcosystemManager.RepositoryTest do
       assert Repository.new(".", "/home/u/DNS/ecosystem").display_name == "ecosystem"
     end
 
+    test "current-directory display name is deterministic (independent of cwd)" do
+      # A relative base path must not be resolved against the working directory.
+      assert Repository.new(".", "some/dir").display_name == "dir"
+    end
+
     test "creates repository struct for named directory" do
       repo = Repository.new("test-repo", "/base/path")
       assert repo.name == "test-repo"


### PR DESCRIPTION
## 概要

workspace ルート（`.`）の表示名のハードコードを撤去し、workspace のディレクトリ名から導出します。

resolve #103

## 問題

`repository.ex` で `.` の表示名が `latex-ecosystem` にハードコードされており、どの workspace でも同じ名前で表示されていました。#101 の複数 workspace 対応で顕在化し、`status --all` で DNS/ecosystem のルートが `latex-ecosystem` と誤表示されていました。

```elixir
defp get_display_name("."), do: "latex-ecosystem"   # ← ハードコード
```

## 対応

`Repository.new/2` で `.` のとき `Path.basename(Path.expand(base_path))` を表示名にします。

```
before(status --all):
  == dns (/home/toshi/prj/DNS/ecosystem) ==
  latex-ecosystem   main   clean   b0e7f74 ...   # ← 誤り

after:
  == dns (/home/toshi/prj/DNS/ecosystem) ==
  ecosystem         main   clean   b0e7f74 ...   # ← 正しい
```

## 動作確認

- `mix test`: 5 doctests, 180 tests, 0 failures / `mix credo --strict`・`mix format --check-formatted`: clean
- escript の `status --all --fast` で latex ルート→`latex-ecosystem`、dns ルート→`ecosystem` と正しく表示されることを確認