### PR TITLE
docs: decide public shared-infra reference strategy for multi-org (#105)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -145,6 +145,26 @@ deployment identity lives in the organization, never in the code.
   plus machine-local details; the org context remains the source of truth.
   See "Tool Configuration Conventions" below for the shared vocabulary.
 
+**Deployment identity vs. shared infrastructure.** The org-scoping rule above
+governs *deployment identity* — registry data, student repositories, rosters,
+notification targets. A second, distinct category is *shared infrastructure*:
+the reusable GitHub Actions workflows (`smkwlab/.github`), composite actions
+(`smkwlab/latex-release-action`, `smkwlab/ai-academic-paper-reviewer`), and the
+DevContainer image (`ghcr.io/smkwlab/texlive-ja-textlint`) that every
+deployment consumes. These are **published as public shared services** and
+referenced literally, because a GitHub Actions `uses:`/`container:` reference
+cannot contain an expression — `${{ github.repository_owner }}` is not
+resolvable there, so a workflow cannot dynamically point at "my own org's"
+copy. The distinction is deliberate: deployment identity must never be a code
+literal (§ above), but a *literal reference to shared infrastructure* is not
+a deployment identity — it is the address of a shared service, and org-specific
+values are injected into it through Actions secrets and variables, never baked
+into the shared workflow. An org that wants to sever this dependency may fork
+the infrastructure and rewrite the references, but the default and recommended
+posture is shared use. See
+[docs/MULTI-ORG-DEPLOYMENT.md](docs/MULTI-ORG-DEPLOYMENT.md) for the concrete
+reference strategy.
+
 ## Template Specialization
 
 ### Document Format Focus

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -124,11 +124,16 @@ any public reusable workflow). An org that needs to sever the dependency — for
 independence, air-gapping, or per-org customization of the reusable logic
 itself — should fork instead; see [When to fork](#when-to-fork).
 
-**Hardening follow-up (not org-specific).** The legacy `ai-reviewer.yml`
-reusable pins `toshi0806/ai-reviewer` — a *personal account*, not even an org —
-which is a single point of failure independent of multi-org concerns. The
-current path is `ai-review.yml` (→ `smkwlab/ai-academic-paper-reviewer`);
-`ai-reviewer.yml` should be retired or repointed to an org-owned action.
+**Out of scope — the legacy `ai-reviewer.yml` reusable.** `smkwlab/.github`
+also ships a legacy `ai-reviewer.yml` reusable that pins `toshi0806/ai-reviewer`
+(a personal account). It is **not part of the deployment path**: no template
+(`sotsuron` / `wr` / `ise-report` / `sotsuron-report` / `latex` / `poster`)
+references it, and `scripts/callers/` ships no caller for it, so newly-created
+repositories and new-org deployments never pick it up — the current AI-review
+path is `ai-review.yml` (→ `smkwlab/ai-academic-paper-reviewer`). Only
+pre-existing repos that still call it are affected. Retiring it (or repointing
+to an org-owned action) is therefore a smkwlab-internal cleanup item for those
+legacy repos, not a multi-org concern.
 
 ### When to fork
 

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -85,24 +85,64 @@ before student-facing flows work in another org:
 | `registry-manager` defaults | Default `github_org: "smkwlab"` can silently target smkwlab student repos; `init` embeds smkwlab links | [registry-manager#45](https://github.com/smkwlab/registry-manager/issues/45) |
 | `thesis-repo-manager.sh` | Fully hardcoded (~20 call sites); unusable outside smkwlab (manual tool, low priority) | [thesis-management-tools#500](https://github.com/smkwlab/thesis-management-tools/issues/500) |
 
-## Shared infrastructure decisions
+## Shared infrastructure: reference strategy
 
-Two pieces of infrastructure are referenced literally from every template and
-need an explicit policy per deployment (discussion in
-[#105](https://github.com/smkwlab/latex-ecosystem/issues/105)):
+Some infrastructure is referenced *literally* (with `smkwlab/` in the string)
+from every template, and — unlike deployment identity — this **cannot** be made
+dynamic: a GitHub Actions `uses:`/`container:` reference may not contain an
+expression, so `${{ github.repository_owner }}` is not resolvable there. A
+workflow therefore cannot point at "my own org's" copy of a reusable workflow
+or action; the org is fixed at the moment the string is written.
 
-- **`smkwlab/.github` reusable workflows** — all template workflows use
-  `uses: smkwlab/.github/.github/workflows/<name>.yml@v1` (draft-chain
-  automation, ML notification, AI review, LaTeX build). Options:
-  - *Shared use*: keep referencing `smkwlab/.github` (requires it to stay
-    public; org-specific values such as notification targets must be
-    externalized).
-  - *Fork*: copy `.github` into the new org and rewrite every `uses:` line
-    in every template.
-- **`ghcr.io/smkwlab/texlive-ja-textlint`** — the DevContainer image
-  referenced by `latex-environment/.devcontainer/devcontainer.json` and the
-  build workflows. Public pulls work as-is; forking the image pipeline is only
-  needed if the org wants independent image maintenance.
+**Decision (#105): treat this as public shared infrastructure.** The following
+are published as public shared services; any organization consumes them by
+referencing `smkwlab/...` directly, and injects its own values through Actions
+secrets and variables rather than editing the shared code:
+
+| Shared service | Referenced by | Per-org input |
+|---|---|---|
+| `smkwlab/.github` reusable workflows (`.github/workflows/<name>.yml@v1`) | template caller workflows (draft-chain, ML notify, AI review, LaTeX build, QA) | secrets / `secrets: inherit` |
+| `smkwlab/latex-release-action@v3` | `latex-build` / `latex-build-modified` reusables | — |
+| `smkwlab/ai-academic-paper-reviewer@v1` | `ai-review` reusable | `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` |
+| `ghcr.io/smkwlab/texlive-ja-textlint` | `devcontainer.json`, build workflows | — |
+
+Why shared use is the default, not fork:
+
+- The reusable **bodies** are already org-agnostic — org derivation uses
+  `github.repository_owner`, and org-specific values (mailing-list address,
+  SMTP, API keys) are consumed through secrets, not hardcoded. Only the
+  *addresses* above carry `smkwlab`.
+- Because `uses:` cannot be templated, forking means rewriting every caller in
+  every template (7 workflows × 5 templates) and re-syncing them on every
+  upstream change. That cost buys independence but nothing else for a
+  deployment that trusts the shared services.
+
+**Accepted trade-offs.** Shared use means a permanent dependency on the
+`smkwlab` org staying public, and template PRs in another org execute
+smkwlab-owned reusable code with that org's secrets (the normal trust model for
+any public reusable workflow). An org that needs to sever the dependency — for
+independence, air-gapping, or per-org customization of the reusable logic
+itself — should fork instead; see [When to fork](#when-to-fork).
+
+**Hardening follow-up (not org-specific).** The legacy `ai-reviewer.yml`
+reusable pins `toshi0806/ai-reviewer` — a *personal account*, not even an org —
+which is a single point of failure independent of multi-org concerns. The
+current path is `ai-review.yml` (→ `smkwlab/ai-academic-paper-reviewer`);
+`ai-reviewer.yml` should be retired or repointed to an org-owned action.
+
+### When to fork
+
+Choose the fork path only when shared use is unacceptable (independence
+requirement, or you need to change the reusable logic per org). Then:
+
+- Copy `smkwlab/.github`, `latex-release-action`, `ai-academic-paper-reviewer`,
+  and the image pipeline into the org, and rewrite `uses:`/`container:`
+  references to the org.
+- Note the two distribution-side seams that assume `smkwlab`: the caller
+  templates in `smkwlab/.github/scripts/callers/*.yml` hardcode the
+  `smkwlab/.github` owner (only the `@__REF__` version is tokenized), and
+  `scripts/distribute-workflow.sh` defaults `ORG="smkwlab"` with no `--org`
+  flag. Both need org parameterization for a fork workflow to be maintainable.
 
 ## Local tool configuration
 


### PR DESCRIPTION
## 概要

統括 Issue #105 の「このリポジトリで決める方針」のうち、**`smkwlab/.github` reusable workflows の参照戦略**を決定し、ドキュメントに書き下す。既存の未決 2 択（Shared use / Fork）を **public 共有インフラ**という決定に置き換える。

## 背景（調査: smkwlab/.github@446e68e の棚卸し）

- **決定的制約**: GitHub Actions の `uses:`/`container:` は式を書けず、reusable workflow / action / image 参照は**動的 org 解決が原理的に不可**。他 org で自 org 複製を使うには文字列書き換えが必須。
- reusable **本体**の大半（claude-qa / draft 生成系 / html-validation / elixir-ci / security）は動的解決・パラメータ化済みで、ML 宛先も secret 化。org 固有値の直書きは無い。
- org 結合点は 5 つ（action 参照 3 種・GHCR イメージ・caller 直書き・Renovate self-extends・distribute スクリプト既定）に集約。うち `toshi0806/ai-reviewer` は org ですらない**個人アカウント依存**で単一障害点。

## 決定

`smkwlab/.github` / `latex-release-action` / `ai-academic-paper-reviewer` / `texlive-ja-textlint` イメージを **public 共有インフラ**と公式に位置づける。他 org は `smkwlab/...` を直接参照し、org 固有値は Actions secret / variable で注入。独立が必要な場合のみ fork（手順を "When to fork" に明記）。

## 変更内容

- **`ECOSYSTEM.md`**（Organization-Scoped Deployment 原則）: *deployment identity*（org 固有・コードにリテラル禁止）と *shared infrastructure*（`uses:` が動的解決不可のためリテラル参照。共有サービスのアドレスであって deployment identity ではない）の区別を追加。
- **`docs/MULTI-ORG-DEPLOYMENT.md`**: "Shared infrastructure decisions"（未決 2 択）を **"Shared infrastructure: reference strategy"（決定済み）** に書き換え。共有サービス表 / shared use を既定とする根拠 / 受容する trade-off / When to fork の手順 / `toshi0806/ai-reviewer` SPOF の hardening follow-up を記載。

## スコープ

- 本 PR は #105 の当該 1 項目（参照戦略の決定）のみ。統括 Issue は close しない（`Refs #105`）。
- `toshi0806/ai-reviewer` の SPOF 解消、distribute スクリプトの `--org` 対応は follow-up として文書化のみ（本 PR では実装しない）。

## テスト

ドキュメントのみの変更。リンク・アンカー（`#when-to-fork`）と ECOSYSTEM.md → docs の相互参照を確認済み。

Refs #105