### PR TITLE
docs: document DevContainer image maintenance policy (#105)

### DIFF
--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -210,9 +210,13 @@ public, or provide pull credentials). What a fork must then repoint to
   org's `latex-environment`
   ([aldc#32](https://github.com/smkwlab/aldc/issues/32)'s
   `ALDC_REPOSITORY_OWNER`).
-- **The `latex-build` / `latex-build-modified` `container:`** — this lives in
-  `smkwlab/.github`, so repointing it means forking `.github` too (see
-  [When to fork](#when-to-fork)).
+- **The CI build image** — `latex-build-modified.yml` pins the *same* image and
+  tag with `container: ghcr.io/smkwlab/texlive-ja-textlint:2026a` (deliberately
+  matching the DevContainer so PDF builds reproduce the dev environment), while
+  `latex-build.yml` reaches the image indirectly through
+  `smkwlab/latex-release-action`. Both live in `smkwlab/.github`, so repointing
+  them means forking `.github` (and the action) too — see
+  [When to fork](#when-to-fork).
 
 ### When to fork
 

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -188,6 +188,32 @@ pre-existing repos that still call it are affected. Retiring it (or repointing
 to an org-owned action) is therefore a smkwlab-internal cleanup item for those
 legacy repos, not a multi-org concern.
 
+### DevContainer image maintenance
+
+The `ghcr.io/smkwlab/texlive-ja-textlint` image (TeXLive + textlint, tagged by
+TeXLive year, e.g. `2026a`) is the default shared image. Public GHCR allows
+anonymous pulls, and `latex-environment`'s `check-texlive-updates.yml` bumps the
+`devcontainer.json` tag automatically when a new image is published — so a
+consuming org needs no image maintenance at all.
+
+Fork the image only for an independent update cadence, to pin or patch TeX
+packages, or to satisfy a registry / air-gap policy. The build pipeline is
+already org-agnostic on publish: `texlive-ja-textlint`'s `build-tag.yml` pushes
+to `ghcr.io/<owner>/texlive-ja-textlint` via `github.repository_owner`, so a
+fork publishes to its own namespace with no code change (make the package
+public, or provide pull credentials). What a fork must then repoint to
+`ghcr.io/<org>/...`:
+
+- **`latex-environment` fork** — the `image` in `devcontainer.json`, **and** the
+  `IMAGE=` constant in `check-texlive-updates.yml`, so the auto-bump tracks the
+  org's image. `aldc` injects this devcontainer, so also point `aldc` at the
+  org's `latex-environment`
+  ([aldc#32](https://github.com/smkwlab/aldc/issues/32)'s
+  `ALDC_REPOSITORY_OWNER`).
+- **The `latex-build` / `latex-build-modified` `container:`** — this lives in
+  `smkwlab/.github`, so repointing it means forking `.github` too (see
+  [When to fork](#when-to-fork)).
+
 ### When to fork
 
 Choose the fork path only when shared use is unacceptable (independence


### PR DESCRIPTION
## 概要

統括 Issue #105 の「このリポジトリで決める方針」の最後の項目 **Docker イメージの独立メンテ方針**。`docs/MULTI-ORG-DEPLOYMENT.md` の "Shared infrastructure" に `### DevContainer image maintenance` サブ節を追加する。

## 現物突合の根拠

- **既定は共有**（PR #108 の public 共有インフラ決定を具体化）: `ghcr.io/smkwlab/texlive-ja-textlint`（TeXLive+textlint、タグ `2026a` 等）は public GHCR で匿名 pull 可。`latex-environment/check-texlive-updates.yml` が新 image 公開時に `devcontainer.json` のタグを自動 bump → 消費側 org は image メンテ不要。
- **ビルドパイプラインは publish が org 非依存**: `texlive-ja-textlint/build-tag.yml` は `ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint` に publish。fork すれば自動的に fork 先 org の namespace に公開される（コード改変不要）。
- **fork 時の付け替え 3 点**: (1) `latex-environment` fork の `devcontainer.json` `image`、(2) 同 `check-texlive-updates.yml` の `IMAGE=`（自動 bump の追従先）、(3) smkwlab/.github の `latex-build`/`latex-build-modified` の `container:`（＝.github fork 経路、When to fork と連動）。

## 変更内容

`docs/MULTI-ORG-DEPLOYMENT.md` に `### DevContainer image maintenance` を追加（既定=共有・自動タグ更新 / fork の判断基準 / publish の org 非依存性 / 付け替え 3 点）。内部アンカー整合確認済み。

## スコープ

本 PR は #105 の当該 1 項目のみ対象。統括 Issue は close しない（`Refs #105`）。**これで「このリポジトリで決める方針」4 項目が全て完了**。残るは個別 `#500`（優先度低）のみ。

## テスト

ドキュメントのみ。内部アンカー参照（`#when-to-fork` 等）が全て見出しに解決することを確認済み。

Refs #105