### PR TITLE
docs: update thesis-management-tools references → student-repo-management

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,7 @@
       "description": "Unified thesis template (undergraduate/graduate)"
     },
     {
-      "name": "thesis-management-tools",
+      "name": "student-repo-management",
       "type": "management_tools",
       "description": "Administrative tools and workflows"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ The manager is an Elixir escript. Build it once with
 # Navigate to specific repository
 cd latex-environment/      # DevContainer template
 cd sotsuron-template/      # Thesis template
-cd thesis-management-tools/ # Administrative tools
+cd student-repo-management/ # Administrative tools
 
 # Each has its own Git repository and CLAUDE.md
 ```
@@ -80,7 +80,7 @@ This directory contains multiple **independent Git repositories**:
 - **latex-template/**: General-purpose LaTeX template
 
 ### Management & Monitoring
-- **thesis-management-tools/**: Repository creation and branch protection automation
+- **student-repo-management/**: Repository creation and branch protection automation
 - **thesis-student-registry/**: Secure student repository registry data (private, data-only)
 - **registry-manager/**: Registry data management tool (Elixir escript, separate repo)
 - **thesis-monitor/**: Student repository monitoring tool (Elixir escript, separate repo)

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,7 +18,7 @@ This document describes the architecture and management strategy for the thesis-
 - **poster-template**: Academic poster template (A0 size, conference presentations)
 
 ### Management & Automation
-- **thesis-management-tools**: Administrative tools and documentation for thesis supervision
+- **student-repo-management**: Administrative tools and documentation for thesis supervision
 - **thesis-student-registry**: Student repository registry data (private, data-only)
 - **registry-manager**: Registry data management tool (Elixir escript)
 - **thesis-monitor**: Student repository monitoring tool (Elixir escript)
@@ -52,7 +52,7 @@ Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)
 ├── ai-academic-paper-reviewer → (AI review for thesis repos & code review, ACADEMIC/CODE modes)
 ├── aldc → latex-environment (release branch)
-├── thesis-management-tools → (Management workflows)
+├── student-repo-management → (Management workflows)
 ├── thesis-student-registry → (Student repository registry data, private)
 ├── registry-manager → thesis-student-registry (writes registry data)
 └── thesis-monitor → thesis-student-registry (reads registry data)
@@ -216,7 +216,7 @@ The ecosystem uses **"registry"** consistently for the student-repository ledger
   a repository_type: it lives in other layers only — the `DOC_TYPE=thesis`
   document flow, the "all theses" filter (`--type thesis` = sotsuron ∪ master),
   and historical repo-name suffixes (real master theses are named `*-master`).
-  Decision record: smkwlab/thesis-management-tools#471.
+  Decision record: smkwlab/student-repo-management#471.
 - **Disambiguation**: "registry" in container/image contexts (texlive-ja-textlint,
   devcontainer docs) means **GitHub Container Registry (ghcr.io)** and is unrelated;
   always spell it out fully there.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ latex-ecosystem/
 ├── poster-template/          # Academic poster (A0)
 #
 #   Management & automation
-├── thesis-management-tools/  # Repository creation / review tooling
+├── student-repo-management/  # Repository creation / review tooling
 ├── thesis-student-registry/  # Student repository registry data (private, data-only)
 ├── ai-academic-paper-reviewer/ # AI review Action (ACADEMIC/CODE modes)
 └── aldc/                     # Adds the LaTeX devcontainer to a repository
@@ -126,17 +126,17 @@ Students should use the automated repository creation process:
 
 **Basic setup (zero dependencies required):**
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)"
 ```
 
 **With student ID specified:**
 ```bash
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)"
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)"
 ```
 
 ### For Faculty
 
-Review workflow documentation is available in `thesis-management-tools/docs/`.
+Review workflow documentation is available in `student-repo-management/docs/`.
 
 ## Documentation
 
@@ -204,7 +204,7 @@ Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)
 ├── ai-academic-paper-reviewer → (AI review for thesis repos & code review, ACADEMIC/CODE modes)
 ├── aldc → latex-environment (release branch)
-├── thesis-management-tools → (Management workflows)
+├── student-repo-management → (Management workflows)
 └── thesis-student-registry → (Student repository registry data; managed by registry-manager, read by thesis-monitor)
 ```
 

--- a/docs/CLAUDE-ARCHITECTURE.md
+++ b/docs/CLAUDE-ARCHITECTURE.md
@@ -61,7 +61,7 @@ latex-ecosystem/                 # This management repository
 - **poster-template/**: Academic poster template (A0, tikzposter + LuaLaTeX)
 
 #### Tools and Automation
-- **thesis-management-tools/**: Administrative tools and workflows
+- **student-repo-management/**: Administrative tools and workflows
 - **thesis-student-registry/**: Student repository registry data (private, data-only; written by registry-manager, read by thesis-monitor)
 - **latex-release-action/**: GitHub Action for LaTeX compilation
 - **ai-academic-paper-reviewer/**: GitHub Action for automated review (ACADEMIC and CODE modes)
@@ -92,7 +92,7 @@ latex-environment (devcontainer)
 sotsuron-template, sotsuron-report-template, ise-report-template,
 wr-template, latex-template, poster-template (templates)
     ↓
-thesis-management-tools (student workflows)
+student-repo-management (student workflows)
     ↓
 thesis-student-registry (registry data)
 ```

--- a/docs/CLAUDE-GIT-WORKFLOW.md
+++ b/docs/CLAUDE-GIT-WORKFLOW.md
@@ -4,7 +4,7 @@ This document covers Git workflow best practices learned from actual development
 
 ## Critical Lesson: Avoid Main Branch Conflicts (2025-06-22)
 
-**Problem Scenario**: During thesis-management-tools development, local main branch diverged from remote main, causing merge conflicts when PR #75 was merged.
+**Problem Scenario**: During student-repo-management development, local main branch diverged from remote main, causing merge conflicts when PR #75 was merged.
 
 **Root Cause Analysis**:
 ```bash

--- a/docs/CLAUDE-SETUP.md
+++ b/docs/CLAUDE-SETUP.md
@@ -69,7 +69,7 @@ git clone https://github.com/smkwlab/latex-ecosystem.git .
 # - texlive-ja-textlint
 # - latex-environment
 # - sotsuron-template
-# - thesis-management-tools
+# - student-repo-management
 # - latex-release-action
 # - ai-academic-paper-reviewer
 # - aldc
@@ -110,7 +110,7 @@ Supporting Infrastructure:
 ├── latex-release-action → (Used by templates)
 ├── ai-academic-paper-reviewer → (Used by thesis repos)  
 ├── aldc → latex-environment (release branch)
-└── thesis-management-tools → (Management workflows)
+└── student-repo-management → (Management workflows)
 ```
 
 ### Standard Update Process
@@ -254,7 +254,7 @@ gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
 ./ecosystem_manager/ecosystem-manager status --long
 
 # Test critical workflows
-cd thesis-management-tools/
+cd student-repo-management/
 ./thesis-repo-manager.sh --test-mode
 
 # Student workflow verification

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -260,10 +260,10 @@ done
 ### Student Repository Creation
 ```bash
 # Create student thesis repository (automated)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash thesis
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash thesis
 
 # Create weekly report repository
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash wr
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash wr
 ```
 
 ### Student Progress Monitoring

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -92,7 +92,7 @@ keys and the ML settings so every student repository inherits them.
 | Secret(s) | Consumed by | Where | Required? |
 |---|---|---|---|
 | `APP_ID`, `APP_PRIVATE_KEY` | Registration automation (`student-repo-management.yml`) | `student-repo-management` | **Yes** — registration cannot run without them |
-| `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` | `ai-review` / `claude-qa` in student repos, and TMT's own `ai-code-review.yml` | Org (student repos) + `student-repo-management` | Optional — the AI jobs skip cleanly when absent |
+| `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` | `ai-review` / `claude-qa` in student repos, and `student-repo-management`'s own `ai-code-review.yml` | Org (student repos) + `student-repo-management` | Optional — the AI jobs skip cleanly when absent |
 | `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`, `LAB_ML_ADDRESS` | `notify-ml-on-pr` reusable (sotsuron / ise / latex templates, `secrets: inherit`) | Org | Required by that workflow — **all six**. To skip ML mail, delete `notify-ml-on-pr.yml` from the templates instead. |
 
 All secret values are plain strings (GitHub secrets are always strings). Set

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -19,7 +19,7 @@ It is resolved per component, at three different layers:
    `github.repository_owner`. The registry repository defaults to the
    convention `<org>/thesis-student-registry` and can be overridden with the
    org/repo variable `REGISTRY_REPO`
-   (`thesis-management-tools/.github/workflows/student-repo-management.yml`).
+   (`student-repo-management/.github/workflows/student-repo-management.yml`).
    No local configuration is involved.
 2. **Local management tools** — resolved from per-tool config files
    (`~/.config/<tool>/config.yml`) with the same convention defaults. See
@@ -36,7 +36,7 @@ It is resolved per component, at three different layers:
 These components follow the *Organization-Scoped Deployment* principle
 (ECOSYSTEM.md) and need no code changes:
 
-- **Repository creation pipeline** (`thesis-management-tools`):
+- **Repository creation pipeline** (`student-repo-management`):
   `student-repo-management.yml`, `process-pending-issues.sh`, and
   `setup-branch-protection.sh` derive the organization from
   `github.repository_owner` / `GITHUB_REPOSITORY` and resolve the registry as
@@ -62,11 +62,11 @@ following before onboarding students. (Verified against
 | Repository | Purpose | Notes |
 |---|---|---|
 | `<org>/thesis-student-registry` (private) | Holds `data/registry.json` | Initialize with `registry-manager init --org <org>` (see [Local tool configuration](#local-tool-configuration)). A non-standard name requires the `REGISTRY_REPO` variable below. |
-| `<org>/thesis-management-tools` | Hosts the registration workflow and `create-repo` scripts | Fork/copy. Carries the App secrets and the fork configuration below. |
+| `<org>/student-repo-management` | Hosts the registration workflow and `create-repo` scripts | Fork/copy. Carries the App secrets and the fork configuration below. |
 | `<org>/sotsuron-template`, `<org>/wr-template`, `<org>/ise-report-template` | Student document templates | **Must exist in the org** — `create-repo` resolves them as `${ORGANIZATION}/<template>`. |
 | `<org>/latex-template`, `<org>/poster-template` | General LaTeX / poster templates | Default to `smkwlab/...` (shared). Only needed in the org if you point `TEMPLATE_REPO` at your own copy. |
 
-### 2. GitHub App (on `<org>/thesis-management-tools`)
+### 2. GitHub App (on `<org>/student-repo-management`)
 
 `student-repo-management.yml` mints a per-run installation token with
 `actions/create-github-app-token` using `owner: <org>`, so a single App reaches
@@ -75,13 +75,13 @@ this repo, the registry, and the student repositories.
 - **Permissions**: `contents: write` (registry commits and repo content),
   `administration: write` (branch protection), `issues: write` (close
   registration issues).
-- **Installation**: org-wide is simplest (must cover `thesis-management-tools`,
+- **Installation**: org-wide is simplest (must cover `student-repo-management`,
   the registry, and the student repositories).
-- **Secrets on `thesis-management-tools`**: `APP_ID`, `APP_PRIVATE_KEY`.
+- **Secrets on `student-repo-management`**: `APP_ID`, `APP_PRIVATE_KEY`.
 
 ### 3. Actions variable (optional)
 
-- `REGISTRY_REPO` on `thesis-management-tools` — set only when the registry
+- `REGISTRY_REPO` on `student-repo-management` — set only when the registry
   repository name deviates from `<org>/thesis-student-registry`.
 
 ### 4. Secrets
@@ -91,8 +91,8 @@ keys and the ML settings so every student repository inherits them.
 
 | Secret(s) | Consumed by | Where | Required? |
 |---|---|---|---|
-| `APP_ID`, `APP_PRIVATE_KEY` | Registration automation (`student-repo-management.yml`) | `thesis-management-tools` | **Yes** — registration cannot run without them |
-| `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` | `ai-review` / `claude-qa` in student repos, and TMT's own `ai-code-review.yml` | Org (student repos) + `thesis-management-tools` | Optional — the AI jobs skip cleanly when absent |
+| `APP_ID`, `APP_PRIVATE_KEY` | Registration automation (`student-repo-management.yml`) | `student-repo-management` | **Yes** — registration cannot run without them |
+| `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` | `ai-review` / `claude-qa` in student repos, and TMT's own `ai-code-review.yml` | Org (student repos) + `student-repo-management` | Optional — the AI jobs skip cleanly when absent |
 | `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`, `LAB_ML_ADDRESS` | `notify-ml-on-pr` reusable (sotsuron / ise / latex templates, `secrets: inherit`) | Org | Required by that workflow — **all six**. To skip ML mail, delete `notify-ml-on-pr.yml` from the templates instead. |
 
 All secret values are plain strings (GitHub secrets are always strings). Set
@@ -103,14 +103,14 @@ so no numeric type is needed.
 
 The forked `create-repo` scripts default every org-specific value to `smkwlab`
 (env vars read by `setup.sh` / `common-lib.sh`; introduced in
-[thesis-management-tools#498](https://github.com/smkwlab/thesis-management-tools/issues/498)
-and [#499](https://github.com/smkwlab/thesis-management-tools/issues/499)). A
+[student-repo-management#498](https://github.com/smkwlab/student-repo-management/issues/498)
+and [#499](https://github.com/smkwlab/student-repo-management/issues/499)). A
 new org overrides:
 
 | Variable | Default | Set to |
 |---|---|---|
 | `DEFAULT_ORG` | `smkwlab` | your org (drives the membership check, target org, and tools owner) |
-| `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` / `TOOLS_CLONE_URL` | `<DEFAULT_ORG>` / `thesis-management-tools` / derived | your fork's location |
+| `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` / `TOOLS_CLONE_URL` | `<DEFAULT_ORG>` / `student-repo-management` / derived | your fork's location |
 | `TEMPLATE_REPO` | `smkwlab/latex-template`, `smkwlab/poster-template` | your copy (latex/poster only; thesis/wr/ise derive from the org) |
 | `ALDC_URL` | `…/smkwlab/aldc/main/aldc` | your aldc copy (or keep the shared one) |
 | `AUTO_ASSIGN_REVIEWER` | `toshi0806` | your reviewer account (empty disables auto-assign) |
@@ -126,8 +126,8 @@ unchanged; a fork sets the knobs in
 
 | Component | What changed | Issue |
 |---|---|---|
-| `setup.sh` (student entry point) | Membership check, target-org guard, and tools clone URL are `DEFAULT_ORG` / `TOOLS_*` overridable | [thesis-management-tools#498](https://github.com/smkwlab/thesis-management-tools/issues/498) ✅ |
-| `create-repo` collateral | `TEMPLATE_REPO` (latex/poster), `ALDC_URL`, `AUTO_ASSIGN_REVIEWER`, `SETUP_GIT_EMAIL_DOMAIN` overrides | [thesis-management-tools#499](https://github.com/smkwlab/thesis-management-tools/issues/499) ✅ |
+| `setup.sh` (student entry point) | Membership check, target-org guard, and tools clone URL are `DEFAULT_ORG` / `TOOLS_*` overridable | [student-repo-management#498](https://github.com/smkwlab/student-repo-management/issues/498) ✅ |
+| `create-repo` collateral | `TEMPLATE_REPO` (latex/poster), `ALDC_URL`, `AUTO_ASSIGN_REVIEWER`, `SETUP_GIT_EMAIL_DOMAIN` overrides | [student-repo-management#499](https://github.com/smkwlab/student-repo-management/issues/499) ✅ |
 | `aldc` installer | `ALDC_REPOSITORY_OWNER` / `ALDC_REPOSITORY_NAME` env override | [aldc#32](https://github.com/smkwlab/aldc/issues/32) ✅ |
 | `thesis-monitor` defaults | Default `github_org` dropped; derived from `registry_repo` owner, otherwise an explicit error | [thesis-monitor#28](https://github.com/smkwlab/thesis-monitor/issues/28) ✅ |
 | `registry-manager` defaults | Default `github_org` dropped; derived from `registry_repo` owner, otherwise an explicit error | [registry-manager#45](https://github.com/smkwlab/registry-manager/issues/45) ✅ |
@@ -136,7 +136,7 @@ unchanged; a fork sets the knobs in
 
 | Component | Problem | Issue |
 |---|---|---|
-| `thesis-repo-manager.sh` | Fully hardcoded (~20 call sites); unusable outside smkwlab. Manual tool, low priority — deprecation is an option | [thesis-management-tools#500](https://github.com/smkwlab/thesis-management-tools/issues/500) |
+| `thesis-repo-manager.sh` | Fully hardcoded (~20 call sites); unusable outside smkwlab. Manual tool, low priority — deprecation is an option | [student-repo-management#500](https://github.com/smkwlab/student-repo-management/issues/500) |
 
 ## Shared infrastructure: reference strategy
 
@@ -266,7 +266,7 @@ After preparing the org and configuration:
    explicit-error-without-config guarantee).
 3. Have a student run `setup.sh` from the fork (configured per
    [create-repo fork configuration](#5-create-repo-fork-configuration)), or file
-   the repository-creation request issue on the org's `thesis-management-tools`
+   the repository-creation request issue on the org's `student-repo-management`
    directly, and confirm: the repository is created in the new org, branch
    protection is applied, and `data/registry.json` in the new org's registry
    gains the entry.

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -341,7 +341,7 @@ branches:
 ### 管理ツール
 - [registry-manager](https://github.com/smkwlab/registry-manager)（レジストリ書き込み・workflow 伝播）
 - [thesis-monitor](https://github.com/smkwlab/thesis-monitor)（学生リポジトリの監視）
-- [thesis-management-tools](../thesis-management-tools/)
+- [student-repo-management](../student-repo-management/)
 
 ---
 

--- a/ecosystem_manager/test/repository_test.exs
+++ b/ecosystem_manager/test/repository_test.exs
@@ -227,7 +227,7 @@ defmodule EcosystemManager.RepositoryTest do
       regular_names = [
         "sotsuron-template",
         "latex-environment",
-        "thesis-management-tools",
+        "student-repo-management",
         "ai-reviewer",
         "custom-repo-name"
       ]

--- a/memo.md
+++ b/memo.md
@@ -17,10 +17,10 @@
   - 各LaTeX系テンプレートに、latex-environment を統合するスクリプト aldc を提供する
   - aldc は aldc リポジトリで開発している
 - テンプレートリポジトリを元に、各学生用の論文執筆・週報執筆リポジトリを作成するためのスクリプトを提供する
- - 提供されるスクリプトは thesis-management-tools/create-repo/setup*.sh
+ - 提供されるスクリプトは student-repo-management/create-repo/setup*.sh
   - このスクリプトは、リポジトリの作成とともに、Pull Request ベースの添削を支援するためのブランチ保護や、リポジトリ一覧ファイルの更新を行う。
   - リポジトリ一覧ファイルはセキュリティの観点から thesis-student-registry リポジトリに作成される
- - thesis-management-tools リポジトリで、その他関連するスクリプトを開発している
+ - student-repo-management リポジトリで、その他関連するスクリプトを開発している
 - 作成されたリポジトリ一覧ファイルを元に、学生の論文・レポート執筆状況を把握するためのスクリプトを提供する。
  - 執筆状況把握用スクリプトは thesis-student-registry/thesis_monitor
 - ai-reviewer は、各リポジトリの Pull Request を自動レビューするための action

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ TEMPLATE_REPOS=(
 )
 
 TOOL_REPOS=(
-    "thesis-management-tools"
+    "student-repo-management"
     "thesis-student-registry"
     "ai-academic-paper-reviewer"
     "aldc"


### PR DESCRIPTION
## 概要

リポジトリ改名 smkwlab/student-repo-management#504（旧 `thesis-management-tools`）に伴う参照追随。ECOSYSTEM.md / README / CLAUDE.md / docs の言及・ツリー図・raw URL・Issue リンク（#471/#498/#499/#500、番号は改名後も維持）、`.claude/settings.json` と `repository_test.exs` の ecosystem-manager エントリ、`setup.sh` の clone 一覧、`memo.md` を更新。

## マージ順序の注意

ecosystem-manager はローカルサブディレクトリ名でリポジトリを解決するため、本 PR は GitHub 改名および `mv thesis-management-tools student-repo-management`（+ `git remote set-url`）とセットでマージ済みであること。※改名・mv は実施済み。

Refs smkwlab/student-repo-management#504