### PR TITLE
docs: fill multi-org deployment gaps found in test-org run

### DIFF
--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -57,11 +57,22 @@ following before onboarding students. (Verified against
 `student-repo-management.yml`, `ai-code-review.yml`, `notify-ml-on-pr.yml`, and
 `create-repo/*.sh`.)
 
+> **Organization plan requirement.** Thesis repositories are created **private**
+> (`create-repo/main.sh` sets `VISIBILITY="private"`) and the registration
+> workflow applies branch protection to them. Branch protection on *private*
+> repositories requires a paid GitHub plan (Team or Enterprise) — on the **Free**
+> plan the protection step fails with HTTP 403 (`Upgrade to GitHub Pro or make
+> this repository public to enable this feature`) and the registration run ends in
+> failure. Put the new org on a plan that allows branch protection on private
+> repositories before onboarding students. (Verified 2026-07-11 on a Free test
+> org: every other step — App token, registry write, issue close — succeeded; only
+> the private-repo branch-protection call was rejected.)
+
 ### 1. Repositories
 
 | Repository | Purpose | Notes |
 |---|---|---|
-| `<org>/thesis-student-registry` (private) | Holds `data/registry.json` | Initialize with `registry-manager init --org <org>` (see [Local tool configuration](#local-tool-configuration)). A non-standard name requires the `REGISTRY_REPO` variable below. |
+| `<org>/thesis-student-registry` (private) | Holds `data/registry.json` | Initialize with `registry-manager init --org <org>` (add `--force` if a config already exists; see [Local tool configuration](#local-tool-configuration)). A non-standard name requires the `REGISTRY_REPO` variable below. |
 | `<org>/student-repo-management` | Hosts the registration workflow and `create-repo` scripts | Fork/copy. Carries the App secrets and the fork configuration below. |
 | `<org>/sotsuron-template`, `<org>/wr-template`, `<org>/ise-report-template` | Student document templates | **Must exist in the org** — `create-repo` resolves them as `${ORGANIZATION}/<template>`. |
 | `<org>/latex-template`, `<org>/poster-template` | General LaTeX / poster templates | Default to `smkwlab/...` (shared). Only needed in the org if you point `TEMPLATE_REPO` at your own copy. |
@@ -245,9 +256,12 @@ defaults**: until the issues above are fixed, both Elixir tools default to
   registry_repo: your-org/thesis-student-registry   # explicit; required for all registry operations
   ```
 
-  Or generate it with `registry-manager init --org your-org`.
+  Or generate it with `registry-manager init --org your-org`. If a config file
+  already exists it is **not** overwritten — add `--force` (the command still
+  creates/repairs the registry repo either way).
 - **thesis-monitor**: run `thesis-monitor init --org your-org` (the `--org`
-  flag works **only** on `init`; runtime commands read the config file).
+  flag works **only** on `init`; runtime commands read the config file). As with
+  registry-manager, an existing config requires `--force` to overwrite.
 - **Student roster (optional)**: place the CSV at
   `~/.config/<your-org>/students.csv` — the convention path follows
   `github_org` automatically.
@@ -268,8 +282,13 @@ After preparing the org and configuration:
    [create-repo fork configuration](#5-create-repo-fork-configuration)), or file
    the repository-creation request issue on the org's `student-repo-management`
    directly, and confirm: the repository is created in the new org, branch
-   protection is applied, and `data/registry.json` in the new org's registry
-   gains the entry.
+   protection is applied (requires a paid plan — see the plan note under
+   [Prerequisites](#prerequisites-in-the-new-organization)), and
+   `data/registry.json` in the new org's registry gains the entry.
+   `setup.sh` runs the creator in an interactive container (`docker run -it`), so
+   it needs a real terminal — for a headless/automated check, run
+   `create-repo/main.sh` directly instead, e.g.
+   `TARGET_ORG=<org> DOC_TYPE=thesis ./main.sh <student-id>`.
 4. Open a draft PR in a created student repository and confirm the template
    workflows (build, draft-chain, review) run without referencing missing
    secrets or private `smkwlab` resources.


### PR DESCRIPTION
## 背景

`docs/MULTI-ORG-DEPLOYMENT.md` の手順を、使い捨てテスト org `smkwlabOrganization-test0` で Verification checklist 全4項目まで実地検証した。コアな主張（automation core が org 非依存に展開できる）は成立したが、手順書に抜けていた3点を今回の実行で確認したため追記する。

## 検証結果(#105 のフォローアップ)

チェックリスト 1〜4 はすべて pass:
- registry-manager / thesis-monitor が新 org の registry を読み、config 無しでは明示エラー(smkwlab へフォールバックしない)
- 学生リポジトリ作成 → ブランチ保護 → registry 登録 → Issue クローズ → workflow success
- draft PR でテンプレート workflow(LaTeX build / draft-chain / paper-review)が smkwlab 公開共有インフラに対しエラーなく動作、AI レビューは clean skip

## 変更内容(発見した手順書の抜け)

1. **Organization plan requirement** — 学生リポジトリは private 作成(`create-repo/main.sh` の `VISIBILITY="private"`)で、登録 workflow がブランチ保護を適用する。**private repo へのブランチ保護は有料プラン(Team/Enterprise)が必要**で、Free プランでは HTTP 403(`Upgrade to GitHub Pro or make this repository public`)で登録 run が失敗する。他のステップ(App トークン・registry 書込・Issue クローズ)はすべて成功し、失敗するのは private-repo のブランチ保護呼び出しのみ。Prerequisites に注記を追加。
2. **`init --force`** — `registry-manager init` / `thesis-monitor init` は既存 config を `--force` なしでは上書きしない。Repositories 表と Local tool configuration に追記。
3. **setup.sh は TTY 必須** — `docker run -it` のため headless/自動環境では失敗する。自動チェックでは `create-repo/main.sh` を直接実行する旨を Verification checklist 3 に追記。

## 検証時の注記

テスト org は Free プランのため、項目3 は学生リポジトリを一時 public 化してブランチ保護以降(保護適用・registry 更新・Issue クローズ)を確認した。テスト org の作成物は残置。

https://claude.ai/code/session_0192M6KPhtwfvzuAY9hgU1Yy