### PR TITLE
docs: add Japanese translations and sync English docs with current ecosystem

### DIFF
--- a/docs/CLAUDE-ARCHITECTURE.ja.md
+++ b/docs/CLAUDE-ARCHITECTURE.ja.md
@@ -101,7 +101,10 @@ wr-template, latex-template, poster-template (テンプレート群)
 student-repo-management (学生ワークフロー)
     ↓
 thesis-student-registry (レジストリデータ)
-    ↑ 書き込み: registry-manager   ↓ 読み取り: thesis-monitor
+
+レジストリツール (依存チェーン外の横断的ツール):
+    registry-manager → thesis-student-registry に書き込み
+    thesis-monitor   → thesis-student-registry を読み取り
 ```
 
 ### 更新の伝播

--- a/docs/CLAUDE-ARCHITECTURE.ja.md
+++ b/docs/CLAUDE-ARCHITECTURE.ja.md
@@ -1,0 +1,116 @@
+# エコシステムアーキテクチャガイド
+
+> 🌐 English version: [CLAUDE-ARCHITECTURE.md](CLAUDE-ARCHITECTURE.md)
+
+このドキュメントでは、LaTeX 卒業論文環境エコシステムのアーキテクチャ、依存関係、連携パターンについて説明します。
+
+## アーキテクチャ概要
+
+### 依存チェーン
+- **texlive-ja-textlint** → **latex-environment** → **テンプレート群**
+- **サポートツール** はテンプレートおよび環境と統合される
+- **管理ツール** はエコシステム全体を連携させる
+
+### バージョン連携
+- 各リポジトリは独立したバージョン管理を行う
+- 互換性マトリクスは ECOSYSTEM.md に記載される
+- 適切な箇所では更新チェーンを自動化する
+
+### 学生ワークフロー
+- 学生は自動化ツールを使ってリポジトリを作成する
+- 管理上のオーバーヘッドのないクリーンなテンプレートを受け取る
+- 教員はレビュー用ワークフローを指導に活用する
+
+## Git リポジトリの境界
+
+### 管理リポジトリの構造
+```
+latex-ecosystem/                 # この管理リポジトリ
+├── .git/                       # 管理ファイル専用の Git
+├── ECOSYSTEM.md                # 追跡対象 - エコシステム概要
+├── README.md                   # 追跡対象 - リポジトリ概要
+├── setup.sh                    # 追跡対象 - エコシステムセットアップスクリプト
+├── ecosystem_manager/          # 追跡対象 - 連携ツール (Elixir escript)
+├── CLAUDE.md                   # 追跡対象 - このファイル
+├── .claude/                    # 追跡対象 - claude 設定
+├── docs/                       # 追跡対象 - エコシステムドキュメント
+│   ├── CLAUDE-ARCHITECTURE.md  # このファイル
+│   └── CLAUDE-WORKFLOWS.md     # ワークフロー例
+│
+├── latex-environment/          # 独立したリポジトリ
+│   ├── .git/                  # 別個の Git リポジトリ
+│   ├── CLAUDE.md              # そのリポジトリ用の別の CLAUDE.md
+│   └── docs/                  # コンポーネント固有のドキュメント
+│
+├── sotsuron-template/          # 独立したリポジトリ
+│   ├── .git/                  # 別個の Git リポジトリ
+│   ├── CLAUDE.md              # そのリポジトリ用の別の CLAUDE.md
+│   └── docs/                  # コンポーネント固有のドキュメント
+│
+└── (その他の独立したリポジトリ...)
+```
+
+### リポジトリのカテゴリ
+
+#### コアインフラストラクチャ
+- **texlive-ja-textlint/**: 日本語 LaTeX コンパイル用の Docker イメージ
+- **latex-environment/**: LaTeX 開発用の DevContainer テンプレート
+
+#### テンプレート
+- **sotsuron-template/**: 統合卒業論文テンプレート(学部/大学院)
+- **sotsuron-report-template/**: 練習用の卒業論文レポートテンプレート
+- **wr-template/**: 週次レポートテンプレート
+- **latex-template/**: 基本的な LaTeX テンプレート
+- **ise-report-template/**: HTML ベースのレポートテンプレート
+- **poster-template/**: 学術ポスターテンプレート (A0, tikzposter + LuaLaTeX)
+
+#### ツールと自動化
+- **student-repo-management/**: 管理用ツールとワークフロー
+- **thesis-student-registry/**: 学生リポジトリのレジストリデータ(プライベート、主にレジストリデータ。registry-manager が書き込み、thesis-monitor が読み取る)
+- **registry-manager/**: レジストリデータ管理ツール(Elixir escript。thesis-student-registry の data/registry.json に書き込む)
+- **thesis-monitor/**: 学生リポジトリ監視ツール(Elixir escript。レジストリを読み取る)
+- **latex-release-action/**: LaTeX コンパイル用の GitHub Action
+- **ai-academic-paper-reviewer/**: 自動レビュー用の GitHub Action (ACADEMIC モードと CODE モード)
+- **aldc/**: LaTeX devcontainer を追加するコマンドラインツール
+
+## 設計原則
+
+### 管理リポジトリの原則
+- **ファイルのみを追跡**: docs/ と ecosystem_manager/ を除きサブディレクトリの内容は追跡しない
+- **連携重視**: リポジトリ横断の連携とドキュメント管理に注力する
+- **独立したコンポーネント**: 各サブディレクトリは別個の Git リポジトリである
+- **docs/ の例外**: エコシステム全体のドキュメントは一元管理する
+
+### コンポーネントリポジトリの原則
+- **独立したバージョン管理**: 各リポジトリが独自のリリースサイクルを持つ
+- **自己完結**: 各リポジトリ内で機能が完結する
+- **連携した更新**: 互換性のためにエコシステム管理を活用する
+- **一貫した構造**: 確立されたパターン (CLAUDE.md, docs/ など) に従う
+
+## エコシステム連携
+
+### リポジトリ横断の依存関係
+```
+texlive-ja-textlint (ベースイメージ)
+    ↓
+latex-environment (devcontainer)
+    ↓
+sotsuron-template, sotsuron-report-template, ise-report-template,
+wr-template, latex-template, poster-template (テンプレート群)
+    ↓
+student-repo-management (学生ワークフロー)
+    ↓
+thesis-student-registry (レジストリデータ)
+    ↑ 書き込み: registry-manager   ↓ 読み取り: thesis-monitor
+```
+
+### 更新の伝播
+1. **ベースレイヤーの変更** (texlive-ja-textlint) → latex-environment でテストする
+2. **環境の変更** (latex-environment) → 依存するテンプレートを更新する
+3. **テンプレートの変更** → 管理ツールと連携する
+4. **ツールの変更** → 既存のテンプレートで検証する
+
+### 互換性管理
+- **バージョンマトリクス**: ECOSYSTEM.md に記載
+- **テスト連携**: 検証には ecosystem_manager/ecosystem-manager を使用する
+- **破壊的変更の伝達**: リポジトリ横断の issue で連携する

--- a/docs/CLAUDE-ARCHITECTURE.md
+++ b/docs/CLAUDE-ARCHITECTURE.md
@@ -26,6 +26,8 @@ This document covers the architecture, dependencies, and coordination patterns f
 latex-ecosystem/                 # This management repository
 ├── .git/                       # Git for management files only
 ├── ECOSYSTEM.md                # Tracked - ecosystem overview
+├── README.md                   # Tracked - repository overview
+├── setup.sh                    # Tracked - ecosystem setup script
 ├── ecosystem_manager/          # Tracked - coordination tool (Elixir escript)
 ├── CLAUDE.md                   # Tracked - this file
 ├── .claude/                    # Tracked - claude configuration
@@ -62,7 +64,9 @@ latex-ecosystem/                 # This management repository
 
 #### Tools and Automation
 - **student-repo-management/**: Administrative tools and workflows
-- **thesis-student-registry/**: Student repository registry data (private, data-only; written by registry-manager, read by thesis-monitor)
+- **thesis-student-registry/**: Student repository registry data (private, primarily registry data; written by registry-manager, read by thesis-monitor)
+- **registry-manager/**: Registry data management tool (Elixir escript; writes data/registry.json in thesis-student-registry)
+- **thesis-monitor/**: Student repository monitoring tool (Elixir escript; reads the registry)
 - **latex-release-action/**: GitHub Action for LaTeX compilation
 - **ai-academic-paper-reviewer/**: GitHub Action for automated review (ACADEMIC and CODE modes)
 - **aldc/**: Command-line tool for adding LaTeX devcontainer
@@ -70,7 +74,7 @@ latex-ecosystem/                 # This management repository
 ## Design Principles
 
 ### Management Repository Principles
-- **Tracks files only**: No subdirectory content except docs/
+- **Tracks files only**: No subdirectory content except docs/ and ecosystem_manager/
 - **Coordination focus**: Cross-repository coordination and documentation
 - **Independent components**: Each subdirectory is a separate Git repository
 - **Exception for docs/**: Ecosystem-wide documentation is centrally managed
@@ -95,6 +99,7 @@ wr-template, latex-template, poster-template (templates)
 student-repo-management (student workflows)
     ↓
 thesis-student-registry (registry data)
+    ↑ writes: registry-manager   ↓ reads: thesis-monitor
 ```
 
 ### Update Propagation

--- a/docs/CLAUDE-ARCHITECTURE.md
+++ b/docs/CLAUDE-ARCHITECTURE.md
@@ -99,7 +99,10 @@ wr-template, latex-template, poster-template (templates)
 student-repo-management (student workflows)
     ↓
 thesis-student-registry (registry data)
-    ↑ writes: registry-manager   ↓ reads: thesis-monitor
+
+Registry tools (cross-cutting, not part of the build/deploy chain):
+    registry-manager → writes thesis-student-registry
+    thesis-monitor   → reads  thesis-student-registry
 ```
 
 ### Update Propagation

--- a/docs/CLAUDE-GIT-WORKFLOW.ja.md
+++ b/docs/CLAUDE-GIT-WORKFLOW.ja.md
@@ -1,0 +1,149 @@
+# Git ワークフローのベストプラクティス
+
+> 🌐 English version: [CLAUDE-GIT-WORKFLOW.md](CLAUDE-GIT-WORKFLOW.md)
+
+このドキュメントは、LaTeX エコシステムでの実際の開発経験から得られた Git ワークフローのベストプラクティスを扱います。
+
+## 重要な教訓: main ブランチのコンフリクトを避ける (2025-06-22)
+
+**問題のシナリオ**: student-repo-management の開発中に、ローカル main ブランチがリモート main から乖離し、PR #75 をマージした際にマージコンフリクトが発生しました。
+
+**根本原因の分析**:
+```bash
+# 何が問題だったか
+git status
+# → Your branch and 'origin/main' have diverged,
+#   and have 9 and 1 different commits each, respectively.
+
+# ローカル main にはリモートに存在しない 9 個の commit があった
+# リモート main には新しい commit が 1 個あった (PR #75 のマージ)
+# → setup-branch-protection.sh で自動マージコンフリクトが発生
+```
+
+**なぜこれが起きたか**:
+- 複数の変更がローカル main ブランチに直接 commit されていた
+- feature 作業が feature ブランチに分離されていなかった
+- ローカル main がリモート main と同期されていなかった
+- PR 作業と直接 commit が混在していた
+
+## 正しい Git ワークフロー
+
+**❌ 問題のあるワークフロー (コンフリクトの原因)**:
+```bash
+# main への直接 commit (これは避ける)
+git checkout main
+git add . && git commit -m "Add feature X"
+git add . && git commit -m "Fix bug Y"
+# ... 複数の直接 commit ...
+# 後で: PR #75 がリモートでマージされる
+git pull origin main  # → コンフリクト!
+```
+
+**✅ 正しいワークフロー**:
+```bash
+# 1. 常にクリーンで最新の main から始める
+git checkout main
+git pull origin main
+
+# 2. すべての変更に対して feature ブランチを作成する
+git checkout -b feature/descriptive-name
+
+# 3. feature ブランチ上で作業する
+git add . && git commit -m "Implement feature X"
+git add . && git commit -m "Add tests for feature X"
+
+# 4. feature ブランチを push して PR を作成する
+git push -u origin feature/descriptive-name
+gh pr create --title "Add feature X" --body "Description..."
+
+# 5. PR がマージされたら、ローカル main を更新する
+git checkout main
+git pull origin main
+git branch -d feature/descriptive-name  # 後片付け
+```
+
+## ブランチ戦略のルール
+
+**コンポーネントリポジトリの場合**:
+1. **main ブランチに直接 commit しない**
+2. **あらゆる変更に必ず feature ブランチを使う**
+3. **feature ブランチは単一の機能/修正に集中させる**
+4. **新しい feature を作る前に main ブランチをリモートと定期的に同期する**
+5. **すべての変更に PR を使い**、レビュープロセスを維持する
+
+**ブランチ命名規則**:
+```bash
+feature/add-student-id-normalization
+fix/github-actions-bash-rematch
+enhance/error-handling-improvements
+docs/update-architecture-guide
+```
+
+## コンフリクトからの復旧
+
+**コンフリクトが発生したとき** (緊急時手順):
+```bash
+# 1. 状況を把握する
+git status
+git log --oneline -n 10
+
+# 2. リセットしても安全な場合 (重要な未 push 作業がない)
+git fetch origin
+git reset --hard origin/main
+
+# 3. ローカルの変更を保存する必要がある場合
+git stash push -m "WIP: local changes before sync"
+git pull origin main
+git stash pop  # 必要ならコンフリクトを手動で解消する
+
+# 4. 新しい作業のために feature ブランチを作成する
+git checkout -b feature/continue-work
+```
+
+## 予防策
+
+**日々のワークフロー**:
+```bash
+# 一日の始まり: main を同期する
+git checkout main && git pull origin main
+
+# 新しい作業の前: feature ブランチを作成する
+git checkout -b feature/today-work
+
+# 一日の終わり: feature ブランチを push する
+git push -u origin feature/today-work
+```
+
+**PR 前のチェックリスト**:
+- [ ] feature ブランチが main と最新の状態に同期されている
+- [ ] すべての commit が集中していて、よく説明されている
+- [ ] ローカルでテストが通る
+- [ ] main とのマージコンフリクトがない
+
+## 緊急時手順
+
+**main ブランチが壊れた場合**:
+```bash
+# ローカル main をリモートに合わせてリセットする
+git checkout main
+git fetch origin
+git reset --hard origin/main
+
+# バックアップ/stash から feature 作業を再作成する
+git checkout -b feature/recovered-work
+# 変更を適用する...
+```
+
+このワークフローは PR #75 で経験したようなマージコンフリクトを防ぎ、エコシステム全体でのスムーズな協働を保証します。
+
+## エコシステムワークフローとの統合
+
+### エコシステム管理リポジトリの場合
+- 同じブランチ戦略のルールを適用する
+- エコシステム全体のドキュメント更新には feature ブランチを使う
+- 複数のコンポーネントリポジトリにまたがる変更を調整する
+
+### コンポーネントリポジトリの場合
+- コンポーネント固有の変更にも同じワークフローに従う
+- エコシステム管理リポジトリとの調整を確実に行う
+- エコシステムとの互換性に対して変更をテストする

--- a/docs/CLAUDE-SETUP.ja.md
+++ b/docs/CLAUDE-SETUP.ja.md
@@ -262,8 +262,9 @@ gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
 ./ecosystem_manager/ecosystem-manager status --long
 
 # 重要なワークフローのテスト
-cd student-repo-management/
-./thesis-repo-manager.sh --test-mode
+# (thesis-repo-manager.sh は student-repo-management#503 で削除済み。
+#  代わりに thesis-monitor でレジストリ／リポジトリの状態を検証する)
+./thesis-monitor/thesis-monitor status --show-protection
 
 # 学生ワークフローの検証
 cd test-repos/

--- a/docs/CLAUDE-SETUP.ja.md
+++ b/docs/CLAUDE-SETUP.ja.md
@@ -1,0 +1,445 @@
+# LaTeX エコシステム セットアップ・管理ガイド
+
+> 🌐 English version: [CLAUDE-SETUP.md](CLAUDE-SETUP.md)
+
+本ガイドは、九州産業大学の LaTeX エコシステムにおけるセットアップ、依存関係管理、リリースプロセスを包括的に解説します。
+
+## 前提条件
+
+### 必須ツール
+- **Git**: バージョン管理システム
+- **GitHub CLI (`gh`)**: PR/Issue の追跡に必須。クローンを容易にするため推奨
+- **Elixir/Mix**（Erlang/OTP を含む）: `ecosystem-manager` escript のビルドと実行に必須
+- **Bash**: シェルインタプリタ（バージョン 3.2 以上）
+
+### 任意ツール
+- **Docker**: Docker イメージのテスト用
+- **VSCode**: 開発に推奨される IDE
+
+### GitHub CLI のセットアップ
+
+```bash
+# GitHub CLI のインストール
+# macOS
+brew install gh
+
+# Ubuntu/Debian  
+sudo apt install gh
+
+# Windows (Scoop を使用)
+scoop install gh
+
+# 認証
+gh auth login
+
+# 認証の確認
+gh auth status
+```
+
+**注意**: エコシステム管理機能をフルに利用するには GitHub CLI の認証が必要です。認証がない場合、PR/Issue の追跡は動作しません。
+
+## クイックセットアップ
+
+```bash
+# ワンライナーによるエコシステムのセットアップ
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/latex-ecosystem/main/setup.sh)"
+```
+
+## 手動セットアップ
+
+### 1. 管理リポジトリのクローン
+
+```bash
+# 開発用ディレクトリの作成
+mkdir latex-ecosystem-dev
+cd latex-ecosystem-dev
+
+# 管理リポジトリのクローン
+gh repo clone smkwlab/latex-ecosystem .
+
+# または git を使用
+git clone https://github.com/smkwlab/latex-ecosystem.git .
+```
+
+### 2. セットアップスクリプトの実行
+
+```bash
+# セットアップスクリプトの実行
+./setup.sh
+
+# これにより、すべてのコンポーネントリポジトリがクローンされます:
+# コア基盤:
+# - texlive-ja-textlint
+# - latex-environment
+# - latex-release-action
+# ドキュメントテンプレート:
+# - sotsuron-template
+# - wr-template
+# - latex-template
+# - sotsuron-report-template
+# - ise-report-template
+# - poster-template
+# ツール:
+# - student-repo-management
+# - thesis-student-registry
+# - ai-academic-paper-reviewer
+# - aldc
+```
+
+### 3. インストールの確認
+
+```bash
+# マネージャを一度ビルドする (Elixir escript)
+(cd ecosystem_manager && mix escript.build)
+
+# エコシステムの状態を確認
+./ecosystem_manager/ecosystem-manager status
+
+# リポジトリ構成とソースを表示
+./ecosystem_manager/ecosystem-manager repos
+```
+
+## 依存関係管理
+
+### エコシステムの依存関係構造
+
+```
+texlive-ja-textlint (Docker base)
+    ↓
+latex-environment (DevContainer template)
+    ↓
+├── sotsuron-template (LaTeX thesis)
+├── ise-report-template (HTML reports with textlint)
+├── wr-template (Weekly reports)
+├── latex-template (Basic LaTeX)
+└── sotsuron-report-template (Thesis reports)
+
+Supporting Infrastructure:
+├── latex-release-action → (Used by templates)
+├── ai-academic-paper-reviewer → (Used by thesis repos)  
+├── aldc → latex-environment (release branch)
+└── student-repo-management → (Management workflows)
+```
+
+### 標準的な更新プロセス
+
+#### フェーズ 1: ベースイメージの更新 (texlive-ja-textlint)
+
+```bash
+cd texlive-ja-textlint/
+
+# feature ブランチの作成
+git checkout -b feature/update-2025d
+
+# 変更を加える (パッケージ更新、セキュリティパッチなど)
+# alpine/package.json, debian/package.json などを編集
+
+# ローカルでテスト
+docker build -f alpine/Dockerfile -t test-alpine .
+docker build -f debian/Dockerfile -t test-debian .
+
+# コミットとプッシュ
+git add .
+git commit -m "Update to TeXLive 2025d with security patches"
+git push origin feature/update-2025d
+
+# PR の作成
+gh pr create --title "Update to TeXLive 2025d" --body "- Security updates
+- Package compatibility fixes
+- Multi-architecture support verified"
+
+# PR の承認とマージの後
+git checkout main && git pull origin main
+git tag 2025d -m "TeXLive 2025d release"
+git push origin 2025d
+```
+
+#### フェーズ 2: 環境の更新 (latex-environment)
+
+```bash
+cd ../latex-environment/
+
+# texlive-ja-textlint の Docker イメージがビルドされるのを待つ
+# レジストリを確認: ghcr.io/smkwlab/texlive-ja-textlint:2025d
+
+# feature ブランチの作成
+git checkout -b feature/update-texlive-2025d
+
+# 新しいイメージを使うよう devcontainer を更新
+vim .devcontainer/devcontainer.json
+# 変更: "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025d"
+
+# 更新のテスト
+# - VS Code で devcontainer を起動
+# - サンプル文書をコンパイル
+# - textlint の機能を確認
+
+# コミットして PR を作成
+git add .devcontainer/devcontainer.json
+git commit -m "Update to texlive-ja-textlint 2025d"
+git push origin feature/update-texlive-2025d
+gh pr create --title "Update to texlive-ja-textlint 2025d" --body "- Update base Docker image
+- Compatibility verified with sample documents"
+```
+
+#### フェーズ 3: テンプレートの更新
+
+```bash
+# 各テンプレートリポジトリを更新
+for template in sotsuron-template wr-template latex-template ise-report-template; do
+    echo "Updating $template..."
+    cd ../$template/
+    
+    # テンプレートは latex-environment を継承するため、通常は直接の変更は不要
+    # ただし互換性を確認し、必要なら更新する
+    
+    # コンパイルのテスト
+    if [ -f "main.tex" ] || [ -f "sotsuron.tex" ]; then
+        # devcontainer 付きの VS Code で開いてテスト
+        echo "Manual testing required for $template"
+    fi
+done
+```
+
+## リリース管理
+
+### リリースの種類
+
+1. **通常更新**（毎月/隔月）
+   - 機能追加、依存関係更新
+   - 後方互換性を壊さない改善
+   - 例: 2025a → 2025b
+
+2. **セキュリティ更新**（必要に応じて）
+   - 重大なセキュリティパッチ
+   - 例: 2025b → 2025b-security
+
+3. **メジャー更新**（年次）
+   - TeXLive のメジャーバージョン更新
+   - アーキテクチャの変更
+   - 例: 2024c → 2025
+
+### リリースワークフロー
+
+#### 1. 計画フェーズ
+
+```bash
+# 主要リポジトリにリリース計画 issue を作成
+gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
+## Release Goals
+- [ ] Security updates for base Alpine/Debian images
+- [ ] Node.js 18 → 20 migration
+- [ ] New textlint rules for academic writing
+
+## Timeline
+- Development: Week 1-2
+- Testing: Week 3
+- Release: Week 4
+
+## Breaking Changes
+- Node.js version requirement change
+- Migration guide needed
+
+## Testing Requirements
+- [ ] Multi-architecture builds (AMD64, ARM64)
+- [ ] Integration tests with latex-environment
+- [ ] Template compilation verification
+"
+```
+
+#### 2. 開発フェーズ
+
+```bash
+# フェーズ 1〜3 の依存関係更新プロセスに従う
+# すべての変更が適切にテストされていることを確認
+# テストの証跡を含む包括的な PR を作成
+```
+
+#### 3. テストフェーズ
+
+```bash
+# エコシステム全体の状態チェック (ブランチ、未コミット変更、PR)
+./ecosystem_manager/ecosystem-manager status --long
+
+# 重要なワークフローのテスト
+cd student-repo-management/
+./thesis-repo-manager.sh --test-mode
+
+# 学生ワークフローの検証
+cd test-repos/
+# リポジトリ作成とコンパイルを確認
+```
+
+#### 4. リリースフェーズ
+
+```bash
+# 依存順にリリースをタグ付け
+cd texlive-ja-textlint/
+git tag 2025d && git push origin 2025d
+
+cd ../latex-environment/
+git tag 2025.1 && git push origin 2025.1
+
+# エコシステムのトラッキングを更新
+cd ../
+vim ECOSYSTEM.md  # 互換性マトリクスを更新
+git add ECOSYSTEM.md
+git commit -m "Update compatibility matrix for 2025d release"
+```
+
+#### 5. 周知フェーズ
+
+```bash
+# リリースアナウンスの作成
+gh release create 2025d --title "TeXLive 2025d Release" --notes "
+## New Features
+- Updated TeXLive packages
+- Enhanced security
+- Improved multi-architecture support
+
+## Breaking Changes
+- Node.js 18 → 20 (update your local development)
+
+## Migration Guide
+See docs/CLAUDE-SETUP.md for update instructions
+"
+
+# 関係者への通知
+# - 研究室ドキュメントの更新
+# - 必要な対応を学生に周知
+# - 必要なら講義資料を更新
+```
+
+## 緊急時手順
+
+### 重大なセキュリティ更新
+
+```bash
+# セキュリティパッチのための緊急ワークフロー
+# 1. 脆弱性の影響を評価
+# 2. hotfix ブランチを作成
+git checkout -b hotfix/security-CVE-2025-XXXX
+
+# 3. 最小限の修正を適用
+# 4. 迅速なテスト
+# 5. 明確な周知を伴う緊急リリース
+git tag 2025b-security1
+gh release create 2025b-security1 --title "Security Hotfix" --notes "
+⚠️ SECURITY UPDATE
+
+Addresses CVE-2025-XXXX in base image.
+All users should update immediately.
+"
+```
+
+### ロールバック手順
+
+```bash
+# リリースが問題を引き起こした場合
+# 1. 問題のあるバージョンを特定
+# 2. 直前の安定タグに戻す
+
+cd texlive-ja-textlint/
+git checkout 2025c  # 直前の安定バージョン
+git tag 2025d-rollback
+git push origin 2025d-rollback
+
+# 3. ロールバック版を使うよう latex-environment を更新
+cd ../latex-environment/
+# devcontainer.json を 2025c または 2025d-rollback を使うよう更新
+
+# 4. ロールバックをユーザに周知
+gh issue create --title "ROLLBACK: 2025d → 2025c" --body "
+Issue identified in 2025d release.
+Temporarily rolling back to 2025c.
+Investigation ongoing.
+"
+```
+
+## エコシステムの保守
+
+### 定常的な保守タスク
+
+```bash
+# 週次の保守
+./ecosystem_manager/ecosystem-manager status --long
+
+# 月次の保守
+# 必要に応じて各リポジトリの最新変更を取得する (git pull)
+# ドキュメントのレビューと更新
+# 上流の更新を確認する (TeXLive, Node.js など)
+
+# 四半期の保守
+# セキュリティ監査
+# パフォーマンスレビュー
+# 学生フィードバックの反映
+```
+
+### 監視とアラート
+
+```bash
+# 以下の監視を設定する:
+# - Docker イメージのビルド失敗
+# - GitHub Actions の失敗
+# - 学生リポジトリ作成の問題
+# - テンプレートのコンパイル失敗
+
+# 状態チェックには ecosystem-manager を利用する (cron / CI など)
+./ecosystem_manager/ecosystem-manager status --fast
+```
+
+## 開発のベストプラクティス
+
+### ブランチ戦略
+- 常に feature ブランチを使う
+- main へ直接コミットしない
+- 説明的なブランチ名を使う: `feature/`, `fix/`, `hotfix/`
+
+### テスト要件
+- すべての変更は自動テストをパスする必要がある
+- テンプレート変更には手動テストを行う
+- クロスプラットフォーム互換性の検証
+
+### ドキュメント
+- ユーザ向けの変更については CHANGELOG.md を更新する
+- 互換性マトリクスを維持する
+- 破壊的変更には移行ガイドを提供する
+
+## トラブルシューティング
+
+### よくある問題
+
+**セットアップスクリプトの失敗**:
+```bash
+# GitHub CLI の認証を確認
+gh auth status
+
+# リポジトリへのアクセスを確認
+gh repo view smkwlab/latex-ecosystem
+
+# 自動セットアップが失敗する場合は手動でクローン
+git clone https://github.com/smkwlab/texlive-ja-textlint.git
+```
+
+**依存関係更新の問題**:
+```bash
+# Docker イメージの利用可否を確認
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2025d
+
+# イメージの互換性を確認
+docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2025d tlmgr --version
+```
+
+**リリースプロセスの問題**:
+```bash
+# GitHub Actions の状態を確認
+gh run list --repo smkwlab/texlive-ja-textlint
+
+# タグ作成を確認
+git tag -l | grep 2025
+
+# レジストリへのアップロードを確認
+# 参照: https://github.com/orgs/smkwlab/packages
+```
+
+追加のトラブルシューティングについては、各リポジトリのドキュメントおよび [CLAUDE-WORKFLOWS.md](CLAUDE-WORKFLOWS.ja.md) を参照してください。

--- a/docs/CLAUDE-SETUP.md
+++ b/docs/CLAUDE-SETUP.md
@@ -8,7 +8,7 @@ This comprehensive guide covers setup, dependency management, and release proces
 - **Git**: Version control system
 - **GitHub CLI (`gh`)**: Required for PR/Issue tracking, recommended for easier cloning
 - **Elixir/Mix** (with Erlang/OTP): Required to build and run the `ecosystem-manager` escript
-- **Bash**: Shell interpreter (version 4.0+)
+- **Bash**: Shell interpreter (version 3.2+)
 
 ### Optional Tools
 - **Docker**: For testing Docker images
@@ -66,16 +66,22 @@ git clone https://github.com/smkwlab/latex-ecosystem.git .
 ./setup.sh
 
 # This will clone all component repositories:
+# Core infrastructure:
 # - texlive-ja-textlint
 # - latex-environment
-# - sotsuron-template
-# - student-repo-management
 # - latex-release-action
-# - ai-academic-paper-reviewer
-# - aldc
+# Document templates:
+# - sotsuron-template
 # - wr-template
 # - latex-template
+# - sotsuron-report-template
 # - ise-report-template
+# - poster-template
+# Tools:
+# - student-repo-management
+# - thesis-student-registry
+# - ai-academic-paper-reviewer
+# - aldc
 ```
 
 ### 3. Verify Installation

--- a/docs/CLAUDE-SETUP.md
+++ b/docs/CLAUDE-SETUP.md
@@ -260,8 +260,9 @@ gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
 ./ecosystem_manager/ecosystem-manager status --long
 
 # Test critical workflows
-cd student-repo-management/
-./thesis-repo-manager.sh --test-mode
+# (thesis-repo-manager.sh was removed in student-repo-management#503;
+#  use thesis-monitor to verify registry / repository health instead)
+./thesis-monitor/thesis-monitor status --show-protection
 
 # Student workflow verification
 cd test-repos/

--- a/docs/CLAUDE-WORKFLOWS.ja.md
+++ b/docs/CLAUDE-WORKFLOWS.ja.md
@@ -1,0 +1,328 @@
+# エコシステム管理ワークフロー
+
+> 🌐 English version: [CLAUDE-WORKFLOWS.md](CLAUDE-WORKFLOWS.md)
+
+このドキュメントは、LaTeX エコシステム管理リポジトリを用いたエコシステム管理タスクに特化したワークフロー例を提供する。
+
+## エコシステム管理コマンド
+
+### コマンドリファレンス
+
+manager は Elixir escript である。最初に
+`(cd ecosystem_manager && mix escript.build)`
+で一度ビルドしておき、その後は以下を実行する:
+
+```bash
+# 全リポジトリの状態を表示(デフォルトコマンド)
+./ecosystem_manager/ecosystem-manager status
+
+# 詳細な状態: ブランチ、未コミットの変更、最新コミット、PR、issue
+./ecosystem_manager/ecosystem-manager status --long
+
+# GitHub API 呼び出しなしの高速な状態表示
+./ecosystem_manager/ecosystem-manager status --fast
+
+# フィルタ: 緊急 issue / オープンな PR / レビュー待ちの PR
+./ecosystem_manager/ecosystem-manager status --urgent-issues
+./ecosystem_manager/ecosystem-manager status --with-prs
+./ecosystem_manager/ecosystem-manager status --needs-review
+
+# 全ワークスペースの状態、または名前指定で特定のワークスペースの状態
+./ecosystem_manager/ecosystem-manager status --all
+./ecosystem_manager/ecosystem-manager status -w dns   # または --workspace NAME
+
+# 並列度を調整(デフォルト: 8)
+./ecosystem_manager/ecosystem-manager status --max-concurrency 4
+
+# リポジトリ設定とソースを表示
+./ecosystem_manager/ecosystem-manager repos
+
+# ワークスペースのリポジトリを自動探索し、ユーザ設定に記録して
+# ワークスペースを登録
+./ecosystem_manager/ecosystem-manager repos --sync
+
+# 解決されるワークスペースパスを表示 / 全ワークスペースを一覧表示
+./ecosystem_manager/ecosystem-manager workspace
+./ecosystem_manager/ecosystem-manager workspace --list
+
+# サンプルのユーザ設定ファイルを作成
+./ecosystem_manager/ecosystem-manager init-config
+
+# 現在の設定を表示
+./ecosystem_manager/ecosystem-manager config
+```
+
+### 状態監視の例
+```bash
+# エコシステムの簡易ヘルスチェック(ブランチ/コミット/変更情報を含む行)
+./ecosystem_manager/ecosystem-manager status --long
+
+# 対応が必要なリポジトリのみを表示
+./ecosystem_manager/ecosystem-manager status --urgent-issues
+./ecosystem_manager/ecosystem-manager status --needs-review
+
+# バージョン互換性は ECOSYSTEM.md(互換性マトリクス)で管理している
+```
+
+## リポジトリ間の移動と操作
+
+### シェルコマンドの落とし穴
+
+#### ディレクトリ間の移動
+```bash
+# エコシステム管理リポジトリでの作業
+pwd  # /path/to/latex-ecosystem (管理リポジトリ)
+git status  # 管理リポジトリの状態を表示
+
+# コンポーネントでの作業
+cd latex-environment/
+pwd  # /path/to/latex-ecosystem/latex-environment (別リポジトリ)
+git status  # latex-environment リポジトリの状態を表示
+
+# 管理リポジトリに戻る
+cd ..
+git status  # 再び管理リポジトリの状態を表示
+```
+
+#### Git 操作
+```bash
+# 管理リポジトリの操作
+git add ECOSYSTEM.md docs/
+git commit -m "Update ecosystem documentation"
+
+# コンポーネントリポジトリの操作
+cd latex-environment/
+git add .devcontainer/devcontainer.json
+git commit -m "Update devcontainer config"
+git push origin feature-branch
+
+# 管理リポジトリに戻る
+cd ..
+git status  # まったく別の Git 履歴
+```
+
+## ワークフローガイドライン
+
+### エコシステムレベルの変更
+
+#### ドキュメントの更新
+```bash
+# エコシステムドキュメントの更新
+vim ECOSYSTEM.md  # エコシステム概要を編集
+vim docs/CLAUDE-ARCHITECTURE.md  # アーキテクチャの詳細を編集
+
+# エコシステムの変更をコミット
+git add ECOSYSTEM.md docs/
+git commit -m "Update ecosystem architecture documentation"
+git push origin main
+```
+
+#### リポジトリ横断の連携
+```bash
+# 現在の状態を確認
+./ecosystem_manager/ecosystem-manager status
+
+# 更新の調整
+vim ECOSYSTEM.md  # 予定している変更を記録
+
+# 影響を受けるリポジトリに issue を作成
+cd latex-environment/
+gh issue create --title "Update for texlive-ja-textlint v2025c"
+
+cd ../sotsuron-template/
+gh issue create --title "Align with updated latex-environment"
+```
+
+### コンポーネント固有の変更
+
+#### コンポーネント内での作業
+```bash
+# 特定のリポジトリへ移動
+cd latex-environment/
+
+# feature ブランチを作成
+git checkout -b feature/update-textlint-config
+
+# 変更を加える
+vim .textlintrc
+git add .textlintrc
+git commit -m "Update textlint configuration"
+
+# push して PR を作成
+git push origin feature/update-textlint-config
+gh pr create --title "Update textlint configuration"
+
+# エコシステム管理リポジトリに戻る
+cd ..
+```
+
+#### コンポーネントの変更追跡
+```bash
+# コンポーネントリポジトリの変更を監視
+cd latex-environment/
+git log --oneline -10
+
+# 変更が他のコンポーネントに影響するか確認
+cd ../sotsuron-template/
+# 更新された latex-environment でテスト
+
+# 互換性ドキュメントを更新
+cd ..
+vim ECOSYSTEM.md  # 互換性マトリクスを更新
+```
+
+## リポジトリ横断の issue 管理
+
+### 連携した issue 作成
+```bash
+# 複数リポジトリに影響するエコシステム全体の変更向け
+echo "Creating coordinated issues for texlive update..."
+
+# エコシステム管理リポジトリに記録
+vim ECOSYSTEM.md  # Known Issues または Planned Updates に追加
+
+# 影響を受けるリポジトリに issue を作成
+repositories=("texlive-ja-textlint" "latex-environment" "sotsuron-template")
+for repo in "${repositories[@]}"; do
+    cd "$repo/"
+    gh issue create --title "Update for TeXLive 2025c" --body "See latex-ecosystem issue #XX"
+    cd ..
+done
+```
+
+### issue の追跡と連携
+```bash
+# リポジトリ横断で進捗を追跡
+./ecosystem_manager/ecosystem-manager status --with-prs
+
+# エコシステム全体で issue の状態を確認
+for repo in */; do
+    if [ -d "$repo/.git" ]; then
+        echo "=== $repo ==="
+        cd "$repo"
+        gh issue list --label "ecosystem-update"
+        cd ..
+    fi
+done
+```
+
+## テストと検証
+
+### エコシステム全体のテスト
+```bash
+# 全リポジトリを検証(ブランチ、未コミットの変更)
+./ecosystem_manager/ecosystem-manager status --long
+
+# テンプレート横断でコンパイルをテスト
+templates=("sotsuron-template" "wr-template" "latex-template")
+for template in "${templates[@]}"; do
+    echo "Testing $template..."
+    cd "$template/"
+    if [ -f "test.tex" ]; then
+        latexmk -pdf test.tex
+    fi
+    cd ..
+done
+```
+
+### 互換性検証
+```bash
+# バージョン互換性は ECOSYSTEM.md(互換性マトリクス)に記載されている。
+# 更新を調整する際に参照すること。
+
+# 依存関係チェーンを検証
+echo "Checking texlive-ja-textlint → latex-environment compatibility..."
+cd latex-environment/
+grep -r "texlive-ja-textlint" .devcontainer/
+
+# テンプレートの互換性を確認
+cd ../sotsuron-template/
+grep -r "latex-environment" .devcontainer/
+```
+
+## エコシステム連携タスク
+
+### リポジトリ横断のドキュメント更新
+```bash
+# エコシステム全体で CLAUDE.md の構成が変わったとき
+./ecosystem_manager/ecosystem-manager status  # 現在の状態を確認
+
+# ドキュメント更新を計画
+for repo in texlive-ja-textlint latex-environment sotsuron-template; do
+    cd $repo/
+    echo "Planning docs update for $repo"
+    # feature ブランチを作成し、docs/ を更新し、PR を作成
+    cd ..
+done
+
+# 進捗を追跡
+./ecosystem_manager/ecosystem-manager status  # 更新を確認
+```
+
+### issue の連携
+```bash
+# エコシステム全体の変更向けに連携した issue を作成
+echo "Creating coordinated issues for major update..."
+
+# エコシステム管理リポジトリに記録
+vim ECOSYSTEM.md  # Known Issues または Planned Updates に追加
+
+# 影響を受けるリポジトリに issue を作成
+repositories=("texlive-ja-textlint" "latex-environment" "sotsuron-template")
+for repo in "${repositories[@]}"; do
+    cd "$repo/"
+    gh issue create --title "Update for ecosystem change XYZ" --body "See latex-ecosystem management repository for coordination"
+    cd ..
+done
+```
+
+## 学生リポジトリワークフロー
+
+### 学生リポジトリの作成
+```bash
+# 学生の卒論リポジトリを作成(自動化)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash thesis
+
+# 週報リポジトリを作成
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash wr
+
+# 末尾の引数で文書タイプを選択する。setup.sh は 5 種類に対応:
+# thesis, wr, latex, ise, poster。
+```
+
+### 学生の進捗監視
+```bash
+# 全学生の卒論進捗を監視
+./thesis-monitor/thesis-monitor status
+
+# 保護状態のみを表示
+./thesis-monitor/thesis-monitor status --show-protection
+
+# 詳細出力
+./thesis-monitor/thesis-monitor status --verbose
+```
+
+## ベストプラクティス
+
+### リポジトリ境界の管理
+- git 操作の前に必ず `pwd` を確認する
+- `git status` で作業中のリポジトリを確認する
+- エコシステムドキュメントは管理リポジトリの docs/ に置く
+- コンポーネントドキュメントはコンポーネントリポジトリの docs/ に置く
+
+### ドキュメント管理
+- **管理リポジトリの docs/**: エコシステム全体のアーキテクチャ、連携ワークフロー
+- **コンポーネントの docs/**: コンポーネント固有の開発、使用方法、トラブルシューティング
+- **相互参照**: 適切な箇所で管理ドキュメントとコンポーネントドキュメントを相互にリンクする
+
+### コミュニケーションのパターン
+- アーキテクチャ上の決定にはエコシステム管理リポジトリを用いる
+- リポジトリ横断の変更には連携した issue を作成する
+- 互換性マトリクスと更新手順を文書化する
+- エコシステムとコンポーネントの関心事の明確な分離を維持する
+
+## 関連ドキュメント
+
+- [CLAUDE-ARCHITECTURE.ja.md](CLAUDE-ARCHITECTURE.ja.md) - エコシステム構造、依存関係、リポジトリ境界
+- [CLAUDE-SETUP.ja.md](CLAUDE-SETUP.ja.md) - エコシステム管理のための環境セットアップ
+- [PR-REVIEW-GUIDELINES.md](PR-REVIEW-GUIDELINES.md) - Pull Request レビューガイドライン

--- a/docs/CLAUDE-WORKFLOWS.md
+++ b/docs/CLAUDE-WORKFLOWS.md
@@ -24,8 +24,26 @@ The manager is an Elixir escript. Build it once with
 ./ecosystem_manager/ecosystem-manager status --with-prs
 ./ecosystem_manager/ecosystem-manager status --needs-review
 
+# Status across every configured workspace, or a specific one by name
+./ecosystem_manager/ecosystem-manager status --all
+./ecosystem_manager/ecosystem-manager status -w dns   # or --workspace NAME
+
+# Tune parallelism (default: 8)
+./ecosystem_manager/ecosystem-manager status --max-concurrency 4
+
 # Show repository configuration and sources
 ./ecosystem_manager/ecosystem-manager repos
+
+# Auto-discover ecosystem repositories, record them in the user config,
+# and register the workspace
+./ecosystem_manager/ecosystem-manager repos --sync
+
+# Show the resolved workspace path / list all configured workspaces
+./ecosystem_manager/ecosystem-manager workspace
+./ecosystem_manager/ecosystem-manager workspace --list
+
+# Create example user configuration files
+./ecosystem_manager/ecosystem-manager init-config
 
 # Show current configuration
 ./ecosystem_manager/ecosystem-manager config
@@ -260,22 +278,25 @@ done
 ### Student Repository Creation
 ```bash
 # Create student thesis repository (automated)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash thesis
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash thesis
 
 # Create weekly report repository
-STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash wr
+STUDENT_ID=k21rs001 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh)" bash wr
+
+# The final argument selects the document type. setup.sh supports five types:
+# thesis, wr, latex, ise, poster.
 ```
 
 ### Student Progress Monitoring
 ```bash
 # Monitor all students' thesis progress
-thesis-monitor status
+./thesis-monitor/thesis-monitor status
 
 # Show only protection status
-thesis-monitor status --show-protection
+./thesis-monitor/thesis-monitor status --show-protection
 
 # Verbose output
-thesis-monitor status --verbose
+./thesis-monitor/thesis-monitor status --verbose
 ```
 
 ## Best Practices
@@ -296,3 +317,9 @@ thesis-monitor status --verbose
 - Create coordinated issues for cross-repository changes
 - Document compatibility matrices and update procedures
 - Maintain clear separation between ecosystem and component concerns
+
+## Related Documentation
+
+- [CLAUDE-ARCHITECTURE.md](CLAUDE-ARCHITECTURE.md) - Ecosystem structure, dependencies, repository boundaries
+- [CLAUDE-SETUP.md](CLAUDE-SETUP.md) - Environment setup for ecosystem management
+- [PR-REVIEW-GUIDELINES.md](PR-REVIEW-GUIDELINES.md) - Pull Request review guidelines

--- a/docs/MULTI-ORG-DEPLOYMENT.ja.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.ja.md
@@ -1,0 +1,310 @@
+# マルチ org 展開ガイド
+
+> 🌐 English version: [MULTI-ORG-DEPLOYMENT.md](MULTI-ORG-DEPLOYMENT.md)
+
+LaTeX 卒論エコシステムを `smkwlab` 以外の GitHub org に展開する方法を説明します。
+2026-07-10 に実施したリポジトリ横断監査
+([#105](https://github.com/smkwlab/latex-ecosystem/issues/105)) に基づいています。
+
+**ステータス**: 自動化の中核は org スコープになっており、以前は `smkwlab` を
+ハードコードしていた学生向けのエントリポイントも、`smkwlab` を既定値とする
+パラメータ化が完了しました（[解消済みブロッカー](#resolved-blockers)を参照）。
+このガイドは、新しい org が用意しなければならないものと、自動化が消費する正確な
+リソースとシークレットを文書化します。**残存ブロッカーはありません** — 最後の
+項目 `thesis-repo-manager.sh` は
+[student-repo-management#503](https://github.com/smkwlab/student-repo-management/pull/503)
+で `main` から削除され、[#500](https://github.com/smkwlab/student-repo-management/issues/500)
+は解消済みです。
+
+## アーキテクチャ: org ↔ レジストリの関係はどう解決されるか
+
+org とレジストリの関係は、中央の設定にはいっさい保存されていません。
+コンポーネントごとに、3 つの異なるレイヤーで解決されます。
+
+1. **GitHub Actions（自動化の中核）** — `github.repository_owner` から動的に
+   導出されます。レジストリリポジトリは既定で
+   `<org>/thesis-student-registry` という規約に従い、org/repo 変数
+   `REGISTRY_REPO` で上書きできます
+   (`student-repo-management/.github/workflows/student-repo-management.yml`)。
+   ローカル設定はいっさい関与しません。
+2. **ローカル管理ツール** — ツールごとの設定ファイル
+   (`~/.config/<tool>/config.yml`) から解決され、同じ規約の既定値を使います。
+   [ローカルツールの設定](#local-tool-configuration)を参照。
+3. **学生向けのエントリポイント** (`setup.sh`, `aldc`, テンプレートワークフロー) —
+   `smkwlab` を既定値とする環境変数のつまみ (`DEFAULT_ORG`, `TEMPLATE_REPO`,
+   `ALDC_URL`, …) でパラメータ化されています。フォークはこれらを設定して
+   自分自身を再ホームします（[create-repo フォークの設定](#5-create-repo-fork-configuration)を参照）。
+   テンプレートワークフローは設計上、依然として `smkwlab/.github` を
+   リテラルで参照します（[共有インフラ](#shared-infrastructure-reference-strategy)を参照）。
+
+## そのまま動くもの
+
+以下のコンポーネントは *Organization-Scoped Deployment* 原則
+(ECOSYSTEM.md) に従っており、コード変更は不要です。
+
+- **リポジトリ作成パイプライン** (`student-repo-management`):
+  `student-repo-management.yml`, `process-pending-issues.sh`,
+  `setup-branch-protection.sh` は org を
+  `github.repository_owner` / `GITHUB_REPOSITORY` から導出し、レジストリを
+  `<org>/thesis-student-registry` として解決します。org をまたぐリクエストは
+  明示的なガードで拒否されます。
+- **レジストリ自動登録**: `data/registry.json` の更新は、解決されたレジストリ
+  リポジトリを使って GitHub API 経由で行われます。認証には実行ごとに発行される
+  GitHub App のインストールトークンを使い、PAT は使いません。
+- **ecosystem_manager**: 完全に org 非依存です。org はワークスペースルートの
+  `origin` リモートから導出され、リポジトリの自動検出はそのオーナーで
+  フィルタリングされます。
+
+<a id="prerequisites-in-the-new-organization"></a>
+## 新しい org における前提条件
+
+自動化は、1 つの GitHub App、1 つのレジストリリポジトリ、一連のテンプレート、
+そして少数のシークレットと変数で駆動されます。学生をオンボーディングする前に、
+以下のすべてを用意してください。（`student-repo-management.yml`,
+`ai-code-review.yml`, `notify-ml-on-pr.yml`, `create-repo/*.sh` に対して
+検証済み。）
+
+> **org プランの要件。** 卒論リポジトリは **private** で作成され
+> (`create-repo/main.sh` が `VISIBILITY="private"` を設定)、登録ワークフローが
+> それらにブランチ保護を適用します。*private* リポジトリへのブランチ保護には
+> 有料の GitHub プラン（Team または Enterprise）が必要です。**Free** プランでは
+> 保護ステップが HTTP 403 (`Upgrade to GitHub Pro or make this repository public
+> to enable this feature`) で失敗し、登録実行は失敗で終わります。学生を
+> オンボーディングする前に、新しい org を private リポジトリへのブランチ保護を
+> 許可するプランに置いてください。（2026-07-11 に Free テスト org で検証済み:
+> 他のすべてのステップ — App トークン、レジストリ書き込み、issue クローズ —
+> は成功し、private リポジトリへのブランチ保護呼び出しだけが拒否されました。）
+
+### 1. リポジトリ
+
+| リポジトリ | 目的 | 備考 |
+|---|---|---|
+| `<org>/thesis-student-registry` (private) | `data/registry.json` を保持 | `registry-manager init --org <org>` で初期化する（設定が既に存在する場合は `--force` を追加。[ローカルツールの設定](#local-tool-configuration)を参照）。非標準の名前を使う場合は後述の `REGISTRY_REPO` 変数が必要。 |
+| `<org>/student-repo-management` | 登録ワークフローと `create-repo` スクリプトをホスト | フォーク/コピー。App シークレットと後述のフォーク設定を保持する。 |
+| `<org>/sotsuron-template`, `<org>/wr-template`, `<org>/ise-report-template` | 学生用ドキュメントテンプレート | **org 内に存在する必要がある** — `create-repo` はこれらを `${ORGANIZATION}/<template>` として解決する。 |
+| `<org>/latex-template`, `<org>/poster-template` | 汎用 LaTeX / ポスターテンプレート | 既定では `smkwlab/...`（共有）。`TEMPLATE_REPO` を自分のコピーに向ける場合にのみ org 内に必要。 |
+
+### 2. GitHub App（`<org>/student-repo-management` 上）
+
+`student-repo-management.yml` は `actions/create-github-app-token` を使い
+`owner: <org>` で実行ごとのインストールトークンを発行するため、単一の App で
+このリポジトリ、レジストリ、学生リポジトリに到達できます。
+
+- **権限**: `contents: write`（レジストリのコミットとリポジトリ内容）、
+  `administration: write`（ブランチ保護）、`issues: write`（登録 issue の
+  クローズ）。
+- **インストール**: org 全体が最もシンプル（`student-repo-management`、
+  レジストリ、学生リポジトリをカバーする必要がある）。
+- **`student-repo-management` 上のシークレット**: `APP_ID`, `APP_PRIVATE_KEY`。
+
+### 3. Actions 変数（任意）
+
+- `student-repo-management` 上の `REGISTRY_REPO` — レジストリリポジトリ名が
+  `<org>/thesis-student-registry` から外れる場合にのみ設定する。
+
+### 4. シークレット
+
+各シークレットは、それを使うワークフローが動く場所に置きます。AI キーと ML の
+設定については、すべての学生リポジトリが継承できるよう **org シークレット** を
+推奨します。
+
+| シークレット | 消費元 | 置き場所 | 必須? |
+|---|---|---|---|
+| `APP_ID`, `APP_PRIVATE_KEY` | 登録自動化 (`student-repo-management.yml`) | `student-repo-management` | **はい** — これがないと登録は実行できない |
+| `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` | 学生リポジトリの `ai-review` / `claude-qa`、および `student-repo-management` 自身の `ai-code-review.yml` | org（学生リポジトリ）＋ `student-repo-management` | 任意 — AI ジョブは無い場合にクリーンにスキップする |
+| `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`, `LAB_ML_ADDRESS` | `notify-ml-on-pr` 再利用可能ワークフロー（sotsuron / ise / latex テンプレート、`secrets: inherit`） | org | このワークフローが要求 — **6 つすべて**。ML メールを省く場合は、代わりにテンプレートから `notify-ml-on-pr.yml` を削除する。 |
+
+すべてのシークレット値はプレーンな文字列です（GitHub シークレットは常に
+文字列）。`SMTP_PORT` は例えば `587` のように設定します。`notify-ml-on-pr` は
+それをそのままメールアクションに渡すため、数値型は不要です。
+
+<a id="5-create-repo-fork-configuration"></a>
+### 5. create-repo フォークの設定
+
+フォークした `create-repo` スクリプトは、org 固有の値すべてを既定で `smkwlab`
+にします（`setup.sh` / `common-lib.sh` が読む環境変数。
+[student-repo-management#498](https://github.com/smkwlab/student-repo-management/issues/498)
+と [#499](https://github.com/smkwlab/student-repo-management/issues/499) で
+導入）。新しい org は以下を上書きします。
+
+| 変数 | 既定値 | 設定する値 |
+|---|---|---|
+| `DEFAULT_ORG` | `smkwlab` | 自分の org（メンバーシップチェック、ターゲット org、tools オーナーを駆動する） |
+| `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` / `TOOLS_CLONE_URL` | `<DEFAULT_ORG>` / `student-repo-management` / 導出 | 自分のフォークの場所 |
+| `TEMPLATE_REPO` | `smkwlab/latex-template`, `smkwlab/poster-template` | 自分のコピー — 任意のドキュメントタイプのテンプレートを上書きする（[#517](https://github.com/smkwlab/student-repo-management/issues/517)）。表示の既定値は latex/poster を駆動し、thesis/wr/ise は org から導出される |
+| `ALDC_URL` | `…/smkwlab/aldc/main/aldc` | 自分の aldc コピー（または共有のものを使い続ける） |
+| `AUTO_ASSIGN_REVIEWER` | `toshi0806` | 自分のレビュアーアカウント（既定は `toshi0806`。自動アサインは割当先が org 外ユーザーの場合のみスキップされる） |
+| `SETUP_GIT_EMAIL_DOMAIN` | `smkwlab.github.io` | 自分のドメイン |
+
+<a id="resolved-blockers"></a>
+## 解消済みブロッカー
+
+他 org への展開を妨げていた `smkwlab` のハードコードは修正されました。各項目は
+`smkwlab` を既定値とするパラメータ化がなされたため、smkwlab の挙動は変わりません。
+フォークは [create-repo フォークの設定](#5-create-repo-fork-configuration) と
+[ローカルツールの設定](#local-tool-configuration) でつまみを設定します。
+
+| コンポーネント | 変更内容 | Issue |
+|---|---|---|
+| `setup.sh`（学生エントリポイント） | メンバーシップチェック、ターゲット org ガード、tools クローン URL を `DEFAULT_ORG` / `TOOLS_*` で上書き可能に | [student-repo-management#498](https://github.com/smkwlab/student-repo-management/issues/498) ✅ |
+| `create-repo` 付随物 | `TEMPLATE_REPO`（latex/poster）、`ALDC_URL`、`AUTO_ASSIGN_REVIEWER`、`SETUP_GIT_EMAIL_DOMAIN` の上書き | [student-repo-management#499](https://github.com/smkwlab/student-repo-management/issues/499) ✅ |
+| `aldc` インストーラ | `ALDC_REPOSITORY_OWNER` / `ALDC_REPOSITORY_NAME` の環境変数上書き | [aldc#32](https://github.com/smkwlab/aldc/issues/32) ✅ |
+| `thesis-monitor` の既定値 | 既定の `github_org` を廃止。`registry_repo` のオーナーから導出、なければ明示的にエラー | [thesis-monitor#28](https://github.com/smkwlab/thesis-monitor/issues/28) ✅ |
+| `registry-manager` の既定値 | 既定の `github_org` を廃止。`registry_repo` のオーナーから導出、なければ明示的にエラー | [registry-manager#45](https://github.com/smkwlab/registry-manager/issues/45) ✅ |
+| `thesis-repo-manager.sh` | 完全にハードコード（約 20 か所の呼び出し箇所）で smkwlab の外では使えない。手動の低優先度ツール — パラメータ化せず `main` から削除 | [student-repo-management#503](https://github.com/smkwlab/student-repo-management/pull/503) で削除し、[#500](https://github.com/smkwlab/student-repo-management/issues/500) を解消 ✅ |
+
+## 残存ブロッカー
+
+なし。
+
+<a id="shared-infrastructure-reference-strategy"></a>
+## 共有インフラ: 参照戦略
+
+一部のインフラは、すべてのテンプレートから *リテラルに*（文字列中に `smkwlab/`
+を含めて）参照されており、展開のアイデンティティとは異なり、これは動的化
+**できません**。GitHub Actions の `uses:`/`container:` 参照には式を含められない
+ため、`${{ github.repository_owner }}` はそこでは解決されません。したがって
+ワークフローは「自分の org」の再利用可能ワークフローやアクションのコピーを
+指すことができず、org は文字列が書かれた時点で固定されます。
+
+**決定 (#105): これを公開された共有インフラとして扱う。** 以下は公開の共有
+サービスとして提供されます。どの org も `smkwlab/...` を直接参照して利用し、
+共有コードを編集する代わりに Actions のシークレットと変数を通じて自分の値を
+注入します。
+
+| 共有サービス | 参照元 | org ごとの入力 |
+|---|---|---|
+| `smkwlab/.github` の再利用可能ワークフロー (`.github/workflows/<name>.yml@v1`) | テンプレートの呼び出し元ワークフロー（draft-chain、ML 通知、AI レビュー、LaTeX ビルド、QA） | シークレット / `secrets: inherit` |
+| `smkwlab/latex-release-action@v3` | `latex-build` / `latex-build-modified` 再利用可能ワークフロー | — |
+| `smkwlab/ai-academic-paper-reviewer@v1` | `ai-review` 再利用可能ワークフロー | `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` |
+| `ghcr.io/smkwlab/texlive-ja-textlint` | `devcontainer.json`、ビルドワークフロー | — |
+
+フォークではなく共有利用が既定である理由:
+
+- 再利用可能ワークフローの **本体** は既に org 非依存です — org の導出は
+  `github.repository_owner` を使い、org 固有の値（メーリングリストアドレス、
+  SMTP、API キー）はハードコードではなくシークレットを通じて消費されます。
+  上記の *アドレス* だけが `smkwlab` を持っています。
+- `uses:` はテンプレート化できないため、フォークするということはすべての
+  テンプレートのすべての呼び出し元を書き換え（7 ワークフロー × 5 テンプレート）、
+  上流の変更のたびに再同期することを意味します。そのコストは独立性を買いますが、
+  共有サービスを信頼する展開にとってはそれ以外に何ももたらしません。
+
+**受け入れるトレードオフ。** 共有利用は、`smkwlab` org が公開されたままで
+あることへの恒久的な依存を意味し、別の org のテンプレート PR はその org の
+シークレットで smkwlab 所有の再利用可能コードを実行します（あらゆる公開
+再利用可能ワークフローにとって通常の信頼モデル）。依存を断ち切る必要がある
+org — 独立性、エアギャップ、または再利用可能ロジックそのものの org ごとの
+カスタマイズのため — は、代わりにフォークすべきです。[フォークすべきとき](#when-to-fork)を
+参照。
+
+**対象外 — レガシーな `ai-reviewer.yml` 再利用可能ワークフロー。**
+`smkwlab/.github` は `toshi0806/ai-reviewer`（個人アカウント）を固定した
+レガシーな `ai-reviewer.yml` 再利用可能ワークフローも提供しています。これは
+**展開経路の一部ではありません**: どのテンプレート
+(`sotsuron` / `wr` / `ise-report` / `sotsuron-report` / `latex` / `poster`) も
+それを参照せず、`scripts/callers/` はそれ用の呼び出し元を提供しないため、
+新規作成されるリポジトリと新しい org の展開がそれを拾うことはありません —
+現在の AI レビュー経路は `ai-review.yml`（→ `smkwlab/ai-academic-paper-reviewer`）
+です。影響を受けるのは、まだそれを呼び出している既存のリポジトリだけです。
+したがってその廃止（または org 所有のアクションへの向け直し）は、それらの
+レガシーリポジトリのための smkwlab 内部のクリーンアップ項目であり、マルチ org
+の懸念ではありません。
+
+### DevContainer イメージのメンテナンス
+
+`ghcr.io/smkwlab/texlive-ja-textlint` イメージ（TeXLive + textlint、TeXLive の年で
+タグ付け、例: `2026a`）が既定の共有イメージです。公開 GHCR は匿名 pull を許可し、
+`latex-environment` の `check-texlive-updates.yml` は新しいイメージが公開された
+ときに `devcontainer.json` のタグを自動的に更新します。そのため、利用する org は
+イメージのメンテナンスをいっさい必要としません。
+
+イメージをフォークするのは、独立した更新頻度が欲しいとき、TeX パッケージを固定
+またはパッチしたいとき、あるいはレジストリ / エアギャップのポリシーを満たしたい
+ときだけです。ビルドパイプラインは公開時点で既に org 非依存です:
+`texlive-ja-textlint` の `build-tag.yml` は `github.repository_owner` を通じて
+`ghcr.io/<owner>/texlive-ja-textlint` に push するため、フォークはコード変更なしで
+自分の名前空間に公開します（パッケージを公開にするか、pull 認証情報を用意する）。
+フォークがその後 `ghcr.io/<org>/...` に向け直さなければならないもの:
+
+- **`latex-environment` フォーク** — `devcontainer.json` の `image`、**および**
+  `check-texlive-updates.yml` の `IMAGE=` 定数（自動更新が org のイメージを
+  追跡するように）。`aldc` はこの devcontainer を注入するため、`aldc` も org の
+  `latex-environment` に向ける
+  （[aldc#32](https://github.com/smkwlab/aldc/issues/32) の
+  `ALDC_REPOSITORY_OWNER`）。
+- **CI ビルドイメージ** — `latex-build-modified.yml` は
+  `container: ghcr.io/smkwlab/texlive-ja-textlint:2026a` で *同じ* イメージと
+  タグを固定します（PDF ビルドが開発環境を再現するよう、意図的に DevContainer に
+  一致させている）。一方 `latex-build.yml` は `smkwlab/latex-release-action` を
+  通じて間接的にイメージに到達します。どちらも `smkwlab/.github` にあるため、
+  向け直すには `.github`（およびアクション）もフォークする必要があります —
+  [フォークすべきとき](#when-to-fork)を参照。
+
+<a id="when-to-fork"></a>
+### フォークすべきとき
+
+フォーク経路を選ぶのは、共有利用が受け入れられないとき（独立性の要件、または
+再利用可能ロジックを org ごとに変える必要があるとき）だけです。その場合:
+
+- `smkwlab/.github`, `latex-release-action`, `ai-academic-paper-reviewer`、
+  そしてイメージパイプラインを org 内にコピーし、`uses:`/`container:` 参照を
+  org に書き換えます。
+- `smkwlab` を前提とする 2 つの配布側の継ぎ目に注意してください:
+  `smkwlab/.github/scripts/callers/*.yml` の呼び出し元テンプレートは
+  `smkwlab/.github` オーナーをハードコードしており（`@__REF__` バージョンのみが
+  トークン化されている）、`scripts/distribute-workflow.sh` は `--org` フラグを
+  持たず `ORG="smkwlab"` を既定にします。フォークのワークフローを保守可能に
+  するには、どちらも org のパラメータ化が必要です。
+
+<a id="local-tool-configuration"></a>
+## ローカルツールの設定
+
+新しい org のスタッフのマシンには、ツールごとの設定が必要です。**各ツールを
+明示的に設定してください**: 両方の Elixir ツールに org の既定値はもうありません
+— org は `registry_repo` のオーナーから導出され、未設定の場合は smkwlab に
+暗黙のフォールバックをせず明示的にエラーになります。以下のとおり設定します。
+
+- **registry-manager**: `~/.config/registry-manager/config.yml`
+
+  ```yaml
+  github_org: your-org
+  registry_repo: your-org/thesis-student-registry   # 明示的に指定。すべてのレジストリ操作に必須
+  ```
+
+  または `registry-manager init --org your-org` で生成します。設定ファイルが
+  既に存在する場合は **上書きされません** — `--force` を追加してください
+  （コマンドはいずれの場合もレジストリリポジトリの作成/修復は行います）。
+- **thesis-monitor**: `thesis-monitor init --org your-org` を実行します
+  （`--org` フラグは `init` でのみ機能します。ランタイムコマンドは設定ファイルを
+  読みます）。registry-manager と同様に、既存の設定を上書きするには `--force` が
+  必要です。
+- **学生名簿（任意）**: CSV を `~/.config/<your-org>/students.csv` に置きます —
+  規約パスは `github_org` に自動的に従います。
+- **ecosystem_manager**: org 設定は不要です。複数のワークスペースを使う場合は
+  `~/.config/ecosystem-manager/config.exs` でワークスペースパスを設定します。
+
+## 検証チェックリスト
+
+org と設定を準備したあと:
+
+1. org を設定した状態で（[ローカルツールの設定](#local-tool-configuration)を
+   参照）、`registry-manager list` は新しい org のレジストリを読みます — そして
+   設定が無い場合は、smkwlab にフォールバックせず明示的にエラーになるように
+   なりました。
+2. `thesis-monitor status` は新しい org のリポジトリのみを報告します（同じく
+   設定が無ければ明示的にエラーになる保証）。
+3. 学生にフォークから `setup.sh` を実行してもらう
+   （[create-repo フォークの設定](#5-create-repo-fork-configuration)に従って
+   設定したもの）か、org の `student-repo-management` に直接リポジトリ作成
+   リクエストの issue を出してもらい、次を確認します: リポジトリが新しい org に
+   作成されること、ブランチ保護が適用されること（有料プランが必要 —
+   [前提条件](#prerequisites-in-the-new-organization)のプラン注記を参照）、
+   そして新しい org のレジストリの `data/registry.json` にエントリが追加される
+   こと。`setup.sh` はクリエータを対話的コンテナ (`docker run -it`) で実行する
+   ため、実際のターミナルが必要です — ヘッドレス/自動化されたチェックでは、
+   代わりに `create-repo/main.sh` を直接実行してください。例:
+   `TARGET_ORG=<org> DOC_TYPE=thesis ./main.sh <student-id>`。
+4. 作成された学生リポジトリでドラフト PR を開き、テンプレートワークフロー
+   （ビルド、draft-chain、レビュー）が、欠けているシークレットや private な
+   `smkwlab` リソースを参照することなく実行されることを確認します。

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -7,8 +7,11 @@ How to deploy the LaTeX thesis ecosystem to a GitHub organization other than
 **Status**: The automation core is organization-scoped, and the student-facing
 entry points that used to hardcode `smkwlab` are now parameterized with
 `smkwlab` defaults (see [Resolved blockers](#resolved-blockers)). This guide
-documents what a new organization must provision, the exact resources and
-secrets the automation consumes, and the one remaining low-priority blocker.
+documents what a new organization must provision and the exact resources and
+secrets the automation consumes. **There are no remaining blockers** — the last
+item, `thesis-repo-manager.sh`, was removed from `main` in
+[student-repo-management#503](https://github.com/smkwlab/student-repo-management/pull/503),
+resolving [#500](https://github.com/smkwlab/student-repo-management/issues/500).
 
 ## Architecture: how the org ↔ registry relationship is resolved
 
@@ -122,9 +125,9 @@ new org overrides:
 |---|---|---|
 | `DEFAULT_ORG` | `smkwlab` | your org (drives the membership check, target org, and tools owner) |
 | `TOOLS_REPO_OWNER` / `TOOLS_REPO_NAME` / `TOOLS_CLONE_URL` | `<DEFAULT_ORG>` / `student-repo-management` / derived | your fork's location |
-| `TEMPLATE_REPO` | `smkwlab/latex-template`, `smkwlab/poster-template` | your copy (latex/poster only; thesis/wr/ise derive from the org) |
+| `TEMPLATE_REPO` | `smkwlab/latex-template`, `smkwlab/poster-template` | your copy — overrides the template for any doc type ([#517](https://github.com/smkwlab/student-repo-management/issues/517)); the default shown drives latex/poster, while thesis/wr/ise derive from the org |
 | `ALDC_URL` | `…/smkwlab/aldc/main/aldc` | your aldc copy (or keep the shared one) |
-| `AUTO_ASSIGN_REVIEWER` | `toshi0806` | your reviewer account (empty disables auto-assign) |
+| `AUTO_ASSIGN_REVIEWER` | `toshi0806` | your reviewer account (defaults to `toshi0806`; auto-assign is skipped only when the reviewer is outside the org) |
 | `SETUP_GIT_EMAIL_DOMAIN` | `smkwlab.github.io` | your domain |
 
 ## Resolved blockers
@@ -142,12 +145,11 @@ unchanged; a fork sets the knobs in
 | `aldc` installer | `ALDC_REPOSITORY_OWNER` / `ALDC_REPOSITORY_NAME` env override | [aldc#32](https://github.com/smkwlab/aldc/issues/32) ✅ |
 | `thesis-monitor` defaults | Default `github_org` dropped; derived from `registry_repo` owner, otherwise an explicit error | [thesis-monitor#28](https://github.com/smkwlab/thesis-monitor/issues/28) ✅ |
 | `registry-manager` defaults | Default `github_org` dropped; derived from `registry_repo` owner, otherwise an explicit error | [registry-manager#45](https://github.com/smkwlab/registry-manager/issues/45) ✅ |
+| `thesis-repo-manager.sh` | Fully hardcoded (~20 call sites) and unusable outside smkwlab; a manual, low-priority tool — removed from `main` rather than parameterized | [student-repo-management#503](https://github.com/smkwlab/student-repo-management/pull/503) removed it, resolving [#500](https://github.com/smkwlab/student-repo-management/issues/500) ✅ |
 
 ## Remaining blocker
 
-| Component | Problem | Issue |
-|---|---|---|
-| `thesis-repo-manager.sh` | Fully hardcoded (~20 call sites); unusable outside smkwlab. Manual tool, low priority — deprecation is an option | [student-repo-management#500](https://github.com/smkwlab/student-repo-management/issues/500) |
+None.
 
 ## Shared infrastructure: reference strategy
 
@@ -245,9 +247,10 @@ requirement, or you need to change the reusable logic per org). Then:
 
 ## Local tool configuration
 
-Faculty machines in the new org need per-tool configuration. **Do not rely on
-defaults**: until the issues above are fixed, both Elixir tools default to
-`github_org: "smkwlab"` and will silently operate on smkwlab data.
+Faculty machines in the new org need per-tool configuration. **Configure each
+tool explicitly**: neither Elixir tool has an org default anymore — they derive
+the org from the `registry_repo` owner and, when it is unset, fail with an
+explicit error instead of silently falling back to smkwlab. Set them as below.
 
 - **registry-manager**: `~/.config/registry-manager/config.yml`
 


### PR DESCRIPTION
## 概要

`docs/` 配下の英語ドキュメント5本の日本語版（`.ja.md`）を追加し、あわせて内容チェックで判明した「現在のエコシステムとの乖離」を英語版・日本語版の両方で修正します。日本語版は英語版の忠実訳のため、内容修正は両者に同一に適用しています。

## 日本語版の追加

各ファイル冒頭に英語版への言語切替リンク（`> 🌐 English version: ...`）を付与:

- `CLAUDE-ARCHITECTURE.ja.md`
- `CLAUDE-GIT-WORKFLOW.ja.md`
- `CLAUDE-SETUP.ja.md`
- `CLAUDE-WORKFLOWS.ja.md`
- `MULTI-ORG-DEPLOYMENT.ja.md`

`PR-REVIEW-GUIDELINES.md` は元から日本語のため対象外。

## 実態反映のための内容修正（英日共通）

### MULTI-ORG-DEPLOYMENT
- 🔴 `thesis-repo-manager.sh`(#500) は #503 で `main` から削除済み → 「残存ブロッカー」から除外し Resolved に移動、Remaining は「なし」に
- 🔴 「Local tool configuration」導入文の自己矛盾を是正（両 Elixir ツールは org 既定値を持たず、未設定時は smkwlab へ silent fallback せず**明示エラー**）
- 🟡 `TEMPLATE_REPO` は #517 で全ドキュメントタイプ上書き可に
- 🟡 `AUTO_ASSIGN_REVIEWER` は空でも無効化されず既定 `toshi0806` にフォールバックする旨に訂正

### CLAUDE-ARCHITECTURE
- 🔴 `registry-manager` / `thesis-monitor` を独立リポジトリとして一覧・依存図に追加
- 🟡 設計原則「tracks files only」を `docs/` と `ecosystem_manager/` を除く、に是正
- 🟢 管理リポジトリのツリーに `README.md` / `setup.sh` を追加、レジストリの "data-only" 表現を緩和

### CLAUDE-SETUP
- 🔴 `setup.sh` のクローン対象を実際の13リポジトリに更新（`sotsuron-report-template` / `poster-template` / `thesis-student-registry` を補完）
- 🟢 Bash 要件を 3.2+ に緩和

### CLAUDE-WORKFLOWS
- 🟡 学生リポジトリ作成 URL を `/v1/` → `/main/` に統一
- 🟡 新しい ecosystem-manager コマンド（`repos --sync`, `workspace`, `init-config` 等）を追記
- 🟢 ドキュメントタイプ5種の明記、`thesis-monitor` の相対実行表記への統一、関連ドキュメントリンクの新設

## 検証

- docs 内の相対リンクはすべて有効（英日で `.ja.md`/`.md` の使い分けも確認）
- 英日でコードフェンス数・見出し数が一致
- `MULTI-ORG-DEPLOYMENT.ja.md` の内部アンカー（参照6件 ⇔ 定義6件）が完全一致

https://claude.ai/code/session_01CjQjvuTJtWoCgRstNh8PY6