### PR TITLE
docs: fix stale github_org default and zero-config claims in ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -227,7 +227,9 @@ The two registry tools share one configuration scheme (decided 2026-07;
 smkwlab/thesis-monitor#14/#16/#18/#20 and registry-manager#16/#18/#21):
 
 - **Shared vocabulary** — the same key means the same thing in both tools:
-  - `github_org`: the deployment organization (default `smkwlab`)
+  - `github_org`: the deployment organization (no default — derived from the
+    `registry_repo` owner when unset, otherwise an explicit error;
+    thesis-monitor#28 / registry-manager#45)
   - `registry_repo`: the registry data repository (`owner/repo`)
   - `csv_path`: the student roster CSV for name resolution (optional)
 - **File format & location**: annotated YAML at `~/.config/<tool-name>/config.yml`
@@ -242,10 +244,14 @@ smkwlab/thesis-monitor#14/#16/#18/#20 and registry-manager#16/#18/#21):
   name resolution is simply skipped — no warning, names show as N/A).
   The roster CSV itself stays **local-only** (it contains personal
   information — never commit it to any repository or to the registry).
-- **Read = zero config, write = explicit**: `thesis-monitor` (reader) runs with
-  no config file at all — `gh auth login` is the only prerequisite.
-  `registry-manager` (writer) requires an explicit `registry_repo`: a write
-  target is never guessed by convention. This asymmetry is a safety feature.
+- **Read = org only, write = explicit**: `thesis-monitor` (reader) needs only
+  the organization (`thesis-monitor init --org <org>` generates the config;
+  `registry_repo` then derives by convention) — beyond that, `gh auth login`
+  is the only prerequisite. `registry-manager` (writer) requires an explicit
+  `registry_repo`: a write target is never guessed by convention. This
+  asymmetry is a safety feature. Neither tool falls back to a default
+  organization: missing org context is an explicit error
+  (thesis-monitor#28 / registry-manager#45).
 - **No backward-compatibility fallbacks**: old keys (`data_dir`, `data_repo`,
   `student_csv`, `registry_dir`), old file names (`repositories.json`), and old
   config locations (`config.json`, `~/.thesis-monitor.yml`) are not read.
@@ -371,5 +377,5 @@ smkwlab/thesis-monitor#14/#16/#18/#20 and registry-manager#16/#18/#21):
 
 ---
 
-*Last Updated: 2026-07-04*  
-*Document Version: 1.2*
+*Last Updated: 2026-07-13*  
+*Document Version: 1.3*


### PR DESCRIPTION
## 概要

「ECOSYSTEM.md の smkwlab もチェック」のレビューに対応します。6箇所を分類した結果、**4箇所は必然**（共有インフラ戦略の定義本体・決定記録の issue 参照）、**2箇所が stale** と判明したため修正します。

## チェック結果

| 箇所 | 判定 |
|---|---|
| 共有インフラアドレス（`smkwlab/.github` 等、Deployment identity vs. shared infrastructure 節） | ✅ 必然 — 戦略を定義する当の箇所 |
| 決定記録の issue 参照（`smkwlab/student-repo-management#471` 等） | ✅ 必然 |
| **`github_org`: … (default `smkwlab`)** | ❌ **stale** — 既定値は thesis-monitor#28 / registry-manager#45 で撤廃済み |
| **「Read = zero config」（thesis-monitor は設定ファイルなしで動く）** | ❌ **stale** — ゼロ設定は撤廃された smkwlab 既定に依存していた性質。現在は org 未設定だと明示エラー |

いずれも #114 で MULTI-ORG-DEPLOYMENT の同種記述を修正した際の**残りのコピー**です（Tool Configuration Conventions 節が #28/#45 より古い）。実装（`thesis-monitor/lib/thesis_monitor/config.ex:14`・`registry-manager/lib/registry_manager/config.ex:27` — いずれも `github_org: nil`）と突き合わせて確認済み。

## 変更内容

- `github_org` の説明を「既定なし — 未設定時は `registry_repo` オーナーから導出、それも無ければ明示エラー」に修正
- 「Read = zero config」→「**Read = org only**」に改題し、reader は org のみ必要（`init --org` で設定生成、`registry_repo` は規約導出）・both ツールとも既定 org へのフォールバックなし、と実装に即して書き換え。write = explicit の非対称原則は維持
- Last Updated / Document Version を更新

差分: 1ファイル、+13 / −7

https://claude.ai/code/session_01CjQjvuTJtWoCgRstNh8PY6