### PR TITLE
docs: list ecosystem-manager as an independent component repo

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -57,7 +57,7 @@ Supporting Infrastructure:
 ├── thesis-student-registry → (Student repository registry data, private)
 ├── registry-manager → thesis-student-registry (writes registry data)
 ├── thesis-monitor → thesis-student-registry (reads registry data)
-└── ecosystem-manager → (reads git / PR / issue status of all ecosystem repos)
+└── ecosystem-manager → (reads status of all ecosystem repos)
 ```
 
 ## Version Compatibility

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -22,6 +22,7 @@ This document describes the architecture and management strategy for the thesis-
 - **thesis-student-registry**: Student repository registry data (private, data-only)
 - **registry-manager**: Registry data management tool (Elixir escript)
 - **thesis-monitor**: Student repository monitoring tool (Elixir escript)
+- **ecosystem-manager**: Cross-repository status tool for the ecosystem workspace (Elixir escript)
 - **ai-academic-paper-reviewer**: GitHub Action for automated review via the org-standard AI review workflow; supports both `ACADEMIC` (paper) and `CODE` review modes, so it is the single AI reviewer for the ecosystem
 - **ai-reviewer** (legacy): standalone code-review Action hosted at `toshi0806/ai-reviewer` (a fork of `Nasubikun/ai-reviewer`). Superseded by `ai-academic-paper-reviewer` (`CODE` mode) and no longer used by the migrated workflows; kept for reference only
 - **aldc**: Command-line tool for adding LaTeX devcontainer to repositories
@@ -55,7 +56,8 @@ Supporting Infrastructure:
 ├── student-repo-management → (Management workflows)
 ├── thesis-student-registry → (Student repository registry data, private)
 ├── registry-manager → thesis-student-registry (writes registry data)
-└── thesis-monitor → thesis-student-registry (reads registry data)
+├── thesis-monitor → thesis-student-registry (reads registry data)
+└── ecosystem-manager → (reads git / PR / issue status of all ecosystem repos)
 ```
 
 ## Version Compatibility
@@ -302,6 +304,7 @@ smkwlab/thesis-monitor#14/#16/#18/#20 and registry-manager#16/#18/#21):
 - **Templates**: Sample document compilation, textlint validation
   - **ise-report-template**: HTML5/CSS quality validation, accessibility checks, Japanese academic writing standards
 - **Actions**: Integration tests with sample repositories
+- **Elixir tools** (ecosystem-manager, registry-manager, thesis-monitor): org-standard Elixir CI (mix test, Credo, Dialyzer) via `smkwlab/.github`
 
 ### Manual Validation
 - Student workflow end-to-end testing

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gh auth status
 
 **Note**: Without GitHub CLI authentication, the ecosystem manager will still work but with limited functionality (no PR/Issue counts).
 
-**Note**: Some ecosystem repositories (e.g. `thesis-student-registry`) are private. `setup.sh` can clone them only with an authenticated GitHub CLI (`gh auth login`) or an SSH key registered on GitHub; the anonymous HTTPS fallback works for public repositories only.
+**Note**: Some ecosystem repositories (e.g. `thesis-student-registry`, `ecosystem-manager`) are private. `setup.sh` can clone them only with an authenticated GitHub CLI (`gh auth login`) or an SSH key registered on GitHub; the anonymous HTTPS fallback works for public repositories only.
 
 ## Quick Start
 


### PR DESCRIPTION
## 概要

#123(ecosystem_manager 分離)の doc フォローアップです。#124 は既存の参照を rename しましたが、**ECOSYSTEM.md はそもそも ecosystem-manager を独立コンポーネントとして列挙していなかった**(以前は管理リポジトリの一部だったため)ので、rename では追加できませんでした。その欠落を補います。

## 変更

- **ECOSYSTEM.md / Repository Overview**: Management & Automation に `ecosystem-manager` を追加(他の Elixir escript と並べて)
- **ECOSYSTEM.md / Dependency Matrix**: `ecosystem-manager`(全 ecosystem repo の status を読む)を追加。box-drawing を修正
- **ECOSYSTEM.md / Automated Testing**: Elixir ツール群(ecosystem-manager / registry-manager / thesis-monitor)の org 標準 CI(mix test / Credo / Dialyzer)を明記。#123 の「CI の穴」観点に対応
- **README.md**: ecosystem-manager は private repo になり setup.sh で clone される。private repo 認証の注記に追記

## 確認

- `git grep` 済み: GETTING-STARTED / MANAGEMENT-WORKFLOWS 等は #124 で更新済みで、`ecosystem-manager` を独立ツールとして正しく扱っている
- 「ecosystem-manager が管理リポジトリの一部/追跡対象」と誤読させる記述が残っていないことを確認済み
- doc のみの変更

Claude-Session: https://claude.ai/code/session_01Jnvhs3pKABL6vvxj9a5ueb