### PR TITLE
docs: remove duplicated learning-steps section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,17 +13,6 @@ This ecosystem supports **thesis writing with LaTeX** through a structured learn
 
 All documents use **Pull Request-based review** for collaborative improvement and educational feedback.
 
-## Educational Philosophy
-
-The system implements a **progressive learning approach**:
-
-- **Step 1**: Students practice LaTeX with weekly reports
-- **Step 2**: Students create thesis reports to learn document structure  
-- **Step 3**: Students learn collaborative review through ISE reports
-- **Step 4**: Students write thesis with full PR-based review support
-
-Each step builds upon previous knowledge while introducing new collaborative writing skills.
-
 ## Quick Start
 
 ### Ecosystem Management Commands


### PR DESCRIPTION
## 概要

常時読み込みされる `CLAUDE.md` から、重複した記述を削除して軽量化する。

## 変更内容

- `## Educational Philosophy` セクションを削除
  - 直前の `## System Purpose` が同じ4ステップの学習進行(Weekly Reports → Thesis Reports → ISE Reports → Final Thesis)を既に説明しており、内容がほぼ言い換えの重複だった
  - System Purpose / Quick Start 以降の各セクションは維持

セッション起動時に毎回読み込まれるファイルのトークン削減が目的で、挙動には影響しない docs のみの変更。