### PR TITLE
docs: document the view/write command role split

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -218,6 +218,13 @@ LaTeX 系テンプレート（sotsuron / wr / sotsuron-report / poster / latex�
   レジストリを書き、`thesis-monitor` はレジストリを索引として読み、学生の
   論文リポジトリを監視する。prefix の非対称は意図的である — 2 つのツールは
   異なる対象を操作している。
+- **コマンドレベルの役割分割**: この読み/書きの境界はコマンドにも貫かれている。
+  `registry-manager list` は registry.json の**保存値のみ**を表示するレジストリ
+  ビュー(GitHub の per-repo 監視は叩かない)。リポジトリの活動時刻・PR 状態・
+  ブランチ保護の live 確認といった GitHub 監視は `thesis-monitor` に一本化されて
+  いる(`status` / `activity` / `pr-stats`)。同じ機能を両ツールに重複させない。
+  コマンド所有権の一覧は [docs/TOOL-CLI-CONVENTIONS.md](docs/TOOL-CLI-CONVENTIONS.md)
+  を参照。
 - **データフィールド**: レジストリが管理するタイムスタンプは `registry_`
   prefix を持つ(`registry_created_at`、`registry_updated_at`)。素の
   `created_at`/`updated_at` はレガシーフィールドである(移行状況は

--- a/docs/TOOL-CLI-CONVENTIONS.md
+++ b/docs/TOOL-CLI-CONVENTIONS.md
@@ -22,6 +22,21 @@ CLI エンジン上に実装されている。アーキテクチャ上の位置�
   省略時に `status` を実行する
 - **exit code**: 成功 0 / エラー 1
 
+## コマンド所有権(見る=thesis-monitor、書く=registry-manager)
+
+レジストリの読み/書きの境界はコマンドにも貫かれている。同じ機能を両ツールに重複させず、各機能で生き残るコマンドは 1 つ。
+
+| 機能 | コマンド | ツール |
+|---|---|---|
+| レジストリの登録内容を確認(GitHub を叩かない保存値ビュー) | `list` | registry-manager |
+| レジストリへの登録・更新・削除・保護マーク | `add` / `update` / `remove` / `protect` / `edit` ほか | registry-manager |
+| repo の live 状態一覧(活動時刻・保護・Latest Branch 等) | `status` | thesis-monitor |
+| 最近のコミット活動 | `activity` | thesis-monitor |
+| PR/Issue 状態(type/state/review-requested/sort) | `pr-stats` | thesis-monitor |
+
+- `--show-protection` は **rm=registry の保存値**(`protection_status`)、**tm=live 取得**で意味が異なる。rm 側の列見出しは `Protection (recorded)` として live と区別する。
+- registry-manager は per-repo の GitHub 監視(活動時刻・PR・live 保護)を行わない。これらは thesis-monitor の役割。
+
 ## 正準オプション語彙
 
 同じフラグは全ツールで同じ意味を持つ。ツール列は そのフラグを持つツール


### PR DESCRIPTION
## 概要

役割分割(見る=thesis-monitor、書く=registry-manager)が実装レベルで ship 済み(tm#61 pr-stats フル移植、rm#84 list 純化+pr-status 削除)になったため、現在形で文書化する(DOC の latex-ecosystem 分)。

Resolves #150 / 親 epic: #149

## 変更内容

- **ECOSYSTEM.md**: 読み/書きの役割記述に「コマンドレベルの役割分割」を追記(rm `list` = registry.json 保存値のレジストリビュー、GitHub 監視は tm の `status`/`activity`/`pr-stats` に一本化)
- **docs/TOOL-CLI-CONVENTIONS.md**: コマンド所有権の表を追加(どの機能がどちらのツールか、`--show-protection` の rm=保存値 / tm=live の差)

registry-manager と thesis-monitor の README/USER_GUIDE は各リポジトリの別 PR で更新(smkwlab/registry-manager / smkwlab/thesis-monitor)。docs/MULTI-ORG-DEPLOYMENT.md の `registry-manager list` 言及はレジストリ確認手順として現状のまま正確なため変更なし。