### PR TITLE
docs: rename the tools' status command to list in aggregation docs

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -21,15 +21,15 @@ ls ecosystem-manager/ecosystem-manager 2>/dev/null || (cd ecosystem-manager && m
 
 ```bash
 # 全体像（branch / uncommitted changes / last commit / PRs / issues）
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # 注意が必要なリポジトリの抽出
-./ecosystem-manager/ecosystem-manager status --needs-review
-./ecosystem-manager/ecosystem-manager status --urgent-issues
-./ecosystem-manager/ecosystem-manager status --with-prs
+./ecosystem-manager/ecosystem-manager list --needs-review
+./ecosystem-manager/ecosystem-manager list --urgent-issues
+./ecosystem-manager/ecosystem-manager list --with-prs
 ```
 
-`--fast` 指定時は `status --fast` のみ（GitHub API 呼び出し無し）。
+`--fast` 指定時は `list --fast` のみ（GitHub API 呼び出し無し）。
 
 ### 3. ドリルダウン
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,18 @@ The manager is an Elixir escript. Build it once with
 
 ```bash
 # Show status of all repositories (default command)
-./ecosystem-manager/ecosystem-manager status
+./ecosystem-manager/ecosystem-manager list
 
 # Detailed status: branch, uncommitted changes, last commit, PRs, issues
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # Fast status without GitHub API calls
-./ecosystem-manager/ecosystem-manager status --fast
+./ecosystem-manager/ecosystem-manager list --fast
 
 # Show only repositories with urgent issues / open PRs / PRs needing review
-./ecosystem-manager/ecosystem-manager status --urgent-issues
-./ecosystem-manager/ecosystem-manager status --with-prs
-./ecosystem-manager/ecosystem-manager status --needs-review
+./ecosystem-manager/ecosystem-manager list --urgent-issues
+./ecosystem-manager/ecosystem-manager list --with-prs
+./ecosystem-manager/ecosystem-manager list --needs-review
 
 # Show repository configuration and sources
 ./ecosystem-manager/ecosystem-manager repos

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -60,7 +60,7 @@ Supporting Infrastructure:
 ├── thesis-student-registry → (Student repository registry data, private)
 ├── registry-manager → thesis-student-registry (writes registry data)
 ├── thesis-monitor → thesis-student-registry (reads registry data)
-├── ecosystem-manager → (reads status of all ecosystem repos)
+├── ecosystem-manager → (reads the state of all ecosystem repos)
 └── registry-manager / thesis-monitor / ecosystem-manager → elixir-tool-kit
     (shared CLI foundation, pinned by semver tag)
 ```
@@ -222,7 +222,7 @@ LaTeX 系テンプレート（sotsuron / wr / sotsuron-report / poster / latex�
   `registry-manager list` は registry.json の**保存値のみ**を表示するレジストリ
   ビュー(GitHub の per-repo 監視は叩かない)。リポジトリの活動時刻・PR 状態・
   ブランチ保護の live 確認といった GitHub 監視は `thesis-monitor` に一本化されて
-  いる(`status` / `activity` / `pr-stats`)。同じ機能を両ツールに重複させない。
+  いる(`list` / `activity` / `pr-stats`)。同じ機能を両ツールに重複させない。
   コマンド所有権の一覧は [docs/TOOL-CLI-CONVENTIONS.md](docs/TOOL-CLI-CONVENTIONS.md)
   を参照。
 - **データフィールド**: レジストリが管理するタイムスタンプは `registry_`

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ LATEX_ECOSYSTEM_BASE="$HOME/work/latex-ecosystem" \
 
 ```bash
 # Check status of all repositories
-./ecosystem-manager/ecosystem-manager status
+./ecosystem-manager/ecosystem-manager list
 
 # Detailed status (branch, uncommitted changes, last commit, PRs, issues)
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # Fast status without GitHub API calls
-./ecosystem-manager/ecosystem-manager status --fast
+./ecosystem-manager/ecosystem-manager list --fast
 
 # Show repository configuration and sources
 ./ecosystem-manager/ecosystem-manager repos

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -40,7 +40,7 @@ cd latex-ecosystem-dev   # setup.sh が既定で作成するディレクトリ�
 (cd ecosystem-manager && mix escript.build)
 
 # 動作確認: 全リポジトリの状態表示
-./ecosystem-manager/ecosystem-manager status
+./ecosystem-manager/ecosystem-manager list
 ```
 
 **手動 clone で構築する場合**（ワンライナーを使わない場合）:
@@ -97,7 +97,7 @@ clone されるリポジトリの一覧は `./ecosystem-manager/ecosystem-manage
 - `data/registry.json` に登録されていること:
 
   ```bash
-  ./thesis-monitor/thesis-monitor status
+  ./thesis-monitor/thesis-monitor list
   ```
 
 どちらかの確認に失敗した場合は、自動化のセットアップガイド
@@ -119,6 +119,6 @@ clone されるリポジトリの一覧は `./ecosystem-manager/ecosystem-manage
   [RELEASE-OPERATIONS.md](RELEASE-OPERATIONS.md)
 - **学生の進捗監視** →
   [thesis-monitor](https://github.com/smkwlab/thesis-monitor)
-  （`thesis-monitor status`）
+  （`thesis-monitor list`）
 - **添削ルールの正典** →
   [PR-REVIEW-GUIDELINES.md](PR-REVIEW-GUIDELINES.md)

--- a/docs/MANAGEMENT-WORKFLOWS.md
+++ b/docs/MANAGEMENT-WORKFLOWS.md
@@ -12,25 +12,25 @@ manager は Elixir escript である。最初に
 
 ```bash
 # 全リポジトリの状態を表示(デフォルトコマンド)
-./ecosystem-manager/ecosystem-manager status
+./ecosystem-manager/ecosystem-manager list
 
 # 詳細な状態: ブランチ、未コミットの変更、最新コミット、PR、issue
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # GitHub API 呼び出しなしの高速な状態表示
-./ecosystem-manager/ecosystem-manager status --fast
+./ecosystem-manager/ecosystem-manager list --fast
 
 # フィルタ: 緊急 issue / オープンな PR / レビュー待ちの PR
-./ecosystem-manager/ecosystem-manager status --urgent-issues
-./ecosystem-manager/ecosystem-manager status --with-prs
-./ecosystem-manager/ecosystem-manager status --needs-review
+./ecosystem-manager/ecosystem-manager list --urgent-issues
+./ecosystem-manager/ecosystem-manager list --with-prs
+./ecosystem-manager/ecosystem-manager list --needs-review
 
 # 全ワークスペースの状態、または名前指定で特定のワークスペースの状態
-./ecosystem-manager/ecosystem-manager status --all
-./ecosystem-manager/ecosystem-manager status -w dns   # または --workspace NAME
+./ecosystem-manager/ecosystem-manager list --all
+./ecosystem-manager/ecosystem-manager list -w dns   # または --workspace NAME
 
 # 並列度を調整(デフォルト: 8)
-./ecosystem-manager/ecosystem-manager status --max-concurrency 4
+./ecosystem-manager/ecosystem-manager list --max-concurrency 4
 
 # リポジトリ設定とソースを表示
 ./ecosystem-manager/ecosystem-manager repos
@@ -53,11 +53,11 @@ manager は Elixir escript である。最初に
 ### 状態監視の例
 ```bash
 # エコシステムの簡易ヘルスチェック(ブランチ/コミット/変更情報を含む行)
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # 対応が必要なリポジトリのみを表示
-./ecosystem-manager/ecosystem-manager status --urgent-issues
-./ecosystem-manager/ecosystem-manager status --needs-review
+./ecosystem-manager/ecosystem-manager list --urgent-issues
+./ecosystem-manager/ecosystem-manager list --needs-review
 
 # バージョン互換性は ECOSYSTEM.md(互換性マトリクス)で管理している
 ```
@@ -118,7 +118,7 @@ git push origin main
 #### リポジトリ横断の連携
 ```bash
 # 現在の状態を確認
-./ecosystem-manager/ecosystem-manager status
+./ecosystem-manager/ecosystem-manager list
 
 # 更新の調整
 vim ECOSYSTEM.md  # 予定している変更を記録
@@ -191,7 +191,7 @@ done
 ### issue の追跡と連携
 ```bash
 # リポジトリ横断で進捗を追跡
-./ecosystem-manager/ecosystem-manager status --with-prs
+./ecosystem-manager/ecosystem-manager list --with-prs
 
 # エコシステム全体で issue の状態を確認
 for repo in */; do
@@ -209,7 +209,7 @@ done
 ### エコシステム全体のテスト
 ```bash
 # 全リポジトリを検証(ブランチ、未コミットの変更)
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # テンプレート横断でコンパイルをテスト
 templates=("sotsuron-template" "wr-template" "latex-template")
@@ -243,7 +243,7 @@ grep -r "latex-environment" .devcontainer/
 ### リポジトリ横断のドキュメント更新
 ```bash
 # エコシステム全体で CLAUDE.md の構成が変わったとき
-./ecosystem-manager/ecosystem-manager status  # 現在の状態を確認
+./ecosystem-manager/ecosystem-manager list  # 現在の状態を確認
 
 # ドキュメント更新を計画
 for repo in texlive-ja-textlint latex-environment sotsuron-template; do
@@ -254,7 +254,7 @@ for repo in texlive-ja-textlint latex-environment sotsuron-template; do
 done
 
 # 進捗を追跡
-./ecosystem-manager/ecosystem-manager status  # 更新を確認
+./ecosystem-manager/ecosystem-manager list  # 更新を確認
 ```
 
 ### issue の連携
@@ -295,13 +295,13 @@ REVIEW_FLOW=true STUDENT_ID=k21rs001 bash <(curl -fsSL https://repo-setup.smkwla
 ### 学生の進捗監視
 ```bash
 # 全学生の卒論進捗を監視
-./thesis-monitor/thesis-monitor status
+./thesis-monitor/thesis-monitor list
 
 # 保護状態のみを表示
-./thesis-monitor/thesis-monitor status --show-protection
+./thesis-monitor/thesis-monitor list --show-protection
 
 # 詳細出力
-./thesis-monitor/thesis-monitor status --verbose
+./thesis-monitor/thesis-monitor list --verbose
 ```
 
 ## ベストプラクティス

--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -287,7 +287,7 @@ org と設定を準備したあと:
    参照）、`registry-manager list` は新しい org のレジストリを読みます — そして
    設定が無い場合は、smkwlab にフォールバックせず明示的にエラーになるように
    なりました。
-2. `thesis-monitor status` は新しい org のリポジトリのみを報告します（同じく
+2. `thesis-monitor list` は新しい org のリポジトリのみを報告します（同じく
    設定が無ければ明示的にエラーになる保証）。
 3. 学生にフォークから `setup.sh` を実行してもらう
    （[create-repo フォークの設定](#5-create-repo-fork-configuration)に従って

--- a/docs/PR-REVIEW-GUIDELINES.md
+++ b/docs/PR-REVIEW-GUIDELINES.md
@@ -230,8 +230,8 @@ PR の総合コメントで行う。
 ./registry-manager/registry-manager propagate-workflow --all --type thesis --dry-run
 
 # 学生リポジトリの進捗・保護状況の監視は thesis-monitor で行う
-./thesis-monitor/thesis-monitor status
-./thesis-monitor/thesis-monitor status --show-protection
+./thesis-monitor/thesis-monitor list
+./thesis-monitor/thesis-monitor list --show-protection
 ```
 
 ### 2. 品質管理システム

--- a/docs/RELEASE-OPERATIONS.md
+++ b/docs/RELEASE-OPERATIONS.md
@@ -163,12 +163,12 @@ gh issue create --title "Release Planning: texlive-ja-textlint 2025d" --body "
 
 ```bash
 # エコシステム全体の状態チェック (ブランチ、未コミット変更、PR)
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # 重要なワークフローのテスト
 # (thesis-repo-manager.sh は student-repo-management#503 で削除済み。
 #  代わりに thesis-monitor でレジストリ／リポジトリの状態を検証する)
-./thesis-monitor/thesis-monitor status --show-protection
+./thesis-monitor/thesis-monitor list --show-protection
 
 # 学生ワークフローの検証
 cd test-repos/
@@ -267,7 +267,7 @@ Investigation ongoing.
 
 ```bash
 # 週次の保守
-./ecosystem-manager/ecosystem-manager status --long
+./ecosystem-manager/ecosystem-manager list --long
 
 # 月次の保守
 # 必要に応じて各リポジトリの最新変更を取得する (git pull)
@@ -290,7 +290,7 @@ Investigation ongoing.
 # - テンプレートのコンパイル失敗
 
 # 状態チェックには ecosystem-manager を利用する (cron / CI など)
-./ecosystem-manager/ecosystem-manager status --fast
+./ecosystem-manager/ecosystem-manager list --fast
 ```
 
 ## 開発のベストプラクティス

--- a/docs/TOOL-CLI-CONVENTIONS.md
+++ b/docs/TOOL-CLI-CONVENTIONS.md
@@ -19,7 +19,7 @@ CLI エンジン上に実装されている。アーキテクチャ上の位置�
 - **help の自動生成**: `--help`(全体)と `<command> --help`(コマンド別)は
   spec から生成される。help を手で編集することはない
 - **デフォルトコマンド**: thesis-monitor と ecosystem-manager はサブコマンド
-  省略時に `status` を実行する
+  省略時に `list` を実行する
 - **exit code**: 成功 0 / エラー 1
 
 ## コマンド所有権(見る=thesis-monitor、書く=registry-manager)
@@ -30,10 +30,11 @@ CLI エンジン上に実装されている。アーキテクチャ上の位置�
 |---|---|---|
 | レジストリの登録内容を確認(GitHub を叩かない保存値ビュー) | `list` | registry-manager |
 | レジストリへの登録・更新・削除・保護マーク | `add` / `update` / `remove` / `protect` / `edit` ほか | registry-manager |
-| repo の live 状態一覧(活動時刻・保護・Latest Branch 等) | `status` | thesis-monitor |
+| repo の live 状態一覧(活動時刻・保護・Latest Branch 等) | `list` | thesis-monitor |
 | 最近のコミット活動 | `activity` | thesis-monitor |
 | PR/Issue 状態(type/state/review-requested/sort) | `pr-stats` | thesis-monitor |
 
+- 各ツールの一覧コマンドは `list`(エイリアス `ls`)で統一されている。何の集合を列挙するかはツール名が示す — registry-manager=レジストリの保存エントリ、thesis-monitor=学生 repo の live 状態、ecosystem-manager=ワークスペースの全リポジトリ。thesis-monitor と ecosystem-manager ではサブコマンド省略時の既定コマンドでもある。
 - `--show-protection` は **rm=registry の保存値**(`protection_status`)、**tm=live 取得**で意味が異なる。rm 側の列見出しは `Protection (recorded)` として live と区別する。
 - registry-manager は per-repo の GitHub 監視(活動時刻・PR・live 保護)を行わない。これらは thesis-monitor の役割。
 
@@ -60,13 +61,16 @@ CLI エンジン上に実装されている。アーキテクチャ上の位置�
 |---|---|---|
 | `--format table\|csv\|json` | 出力形式(**long のみ**) | rm / tm |
 | `--type` | リポジトリタイプで絞り込み(enum 検証) | rm / tm |
+| `-a`, `--show-archived` | 一覧に archive 済みも含める(既定は現役のみ) | rm / tm |
 | `-l`, `--long` | 詳細表示 | rm / tm / em |
 | `-t` | 時刻順ソート | rm / tm(短縮形のみ・long なし)/ em(`--time-sort` の短縮形) |
-| `-r`, `--reverse` | ソート順を反転 | rm / tm |
+| `-r`, `--reverse` | ソート順を反転 | rm / tm / em |
 | `--no-cache` | キャッシュを使用しない | rm / tm / em |
 | `-d`, `--dry-run` | 実際の変更を行わない | rm |
 | `-f`, `--force` | 確認スキップ / 既存を上書き | rm / tm(init: long のみ) |
 | `--fast` | GitHub API を呼ばない高速モード(long のみ) | em |
+
+`-a` / `-l` / `-t` / `-r` は各ツールの `list` コマンドの表示・ソートオプションとして揃っている(archive 表示・詳細表示・時刻順ソート・反転)。
 
 ### 予約
 


### PR DESCRIPTION
## 概要

thesis-monitor / ecosystem-manager の一覧コマンドが `status` から `list`(エイリアス `ls`、サブコマンド省略時の既定)に統一され、`status` はコマンドとして存在しなくなった(RM/TM/EM の 3 変更は merge 済み)。latex-ecosystem リポジトリの集約文書を ship 済み実装に合わせて現在形で更新する。各ツールの README/USER_GUIDE は各ツールの PR で更新済みのため触っていない。

## 変更内容

- **docs/TOOL-CLI-CONVENTIONS.md**
  - コマンド所有権の表: thesis-monitor の一覧コマンドを `status` → `list`
  - 「各ツールの一覧コマンドは `list`(alias `ls`)。何の集合を列挙するかはツール名が示す」旨を明記
  - 正準オプション語彙に `-a`(`--show-archived`、rm/tm)を追記、`-r` を em にも拡張、`-a`/`-l`/`-t`/`-r` が `list` の表示・ソートオプションとして揃っていることを明記
  - 既定コマンドの記述を `list` に更新
- **ECOSYSTEM.md**: 役割分割節のコマンド列挙を `list` / `activity` / `pr-stats` に更新。依存ツリーの記述を state に(旧 status コマンドとの混同回避)
- **README.md / CLAUDE.md / docs/(GETTING-STARTED・RELEASE-OPERATIONS・MANAGEMENT-WORKFLOWS・PR-REVIEW-GUIDELINES・MULTI-ORG-DEPLOYMENT)/ .claude/skills/triage**: `ecosystem-manager status` / `thesis-monitor status` の呼び出し例をすべて `list` に更新。放置すると削除済みコマンドを案内する壊れた例になるため横断修正した(検証で要求される docs/ の一致に加え、他の集約文書も同じ壊れたコマンドを含んでいたため)

破壊的変更なし(文書のみ)。

## 確認済み

- `grep` で docs/ と ECOSYSTEM.md に一覧コマンドとしての旧 `status` 参照が残っていないこと(`gh auth status` / `git status` の別用途のみ残存)
- 各ツールの spec を確認: em/tm とも `list` の alias は `["ls"]` のみで `status` は非存在、`-a`=`--show-archived`(rm/tm)、`-r`=rm/tm/em を裏取り

Resolves #153
親 epic: smkwlab/latex-ecosystem#152

https://claude.ai/code/session_015FdaeD1BANgCMUcNTUjKVV