### PR TITLE
docs: correct the version matrix to the shipped versions

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -69,15 +69,15 @@ Supporting Infrastructure:
 
 | コンポーネント | 現行バージョン | 互換対象 | 更新頻度 |
 |-----------|----------------|-----------------|------------------|
-| texlive-ja-textlint | 2026a | TeXLive 2026 | 年次(TeXLive リリース) |
-| latex-environment | release ブランチ | texlive-ja-textlint:2026a | 自動(main へのマージ時) |
+| texlive-ja-textlint | 2026d | TeX Live 2025 | 随時(イメージ更新ごと) |
+| latex-environment | release ブランチ | texlive-ja-textlint:2026d | 自動(main へのマージ時) |
 | sotsuron-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
 | ise-report-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
 | latex-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
 | wr-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
 | sotsuron-report-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
 | poster-template | 最新 | aldc 経由で自動更新 | 手動更新不要 |
-| latex-release-action | v3.3.0 | 全テンプレート | 機能ごと |
+| latex-release-action | v3.5.0 | 全テンプレート | 機能ごと |
 | aldc | 最新 | latex-environment:release | 更新不要 |
 | ecosystem-manager | 最新 | Elixir ~> 1.17 (OTP 27+) | 機能ごと |
 | elixir-tool-kit | v0.3.0 | Elixir ~> 1.17 (OTP 27+) | 利用ツールが tag 固定で pin |
@@ -327,7 +327,8 @@ latex-ecosystem#146):
 
 ### タグ戦略
 - **セマンティックバージョニング**: v{MAJOR}.{MINOR}.{PATCH}
-- **カレンダーバージョニング**: texlive-ja-textlint 用(例: 2025b)
+- **カレンダーバージョニング**: texlive-ja-textlint 用(例: 2026d)。年はイメージの
+  リリース系列であって、同梱する TeX Live の版ではない
 - **協調リリース**: エコシステムの大規模更新時
 
 ## 開発ワークフロー
@@ -435,5 +436,5 @@ latex-ecosystem#146):
 
 ---
 
-*Last Updated: 2026-07-18*  
+*Last Updated: 2026-08-04*  
 *Document Version: 1.4(ドキュメントを日本語化)*


### PR DESCRIPTION
## 背景

バージョン互換性の表が実体とずれていた。タグの遅れだけでなく、**同梱する TeX Live の版そのものが誤っていた**。

| 記述 | 実体 | 確認方法 |
|---|---|---|
| texlive-ja-textlint `2026a` | `2026d` | `.devcontainer/devcontainer.json`（latex-environment main / release とも） |
| 互換対象 **TeXLive 2026** | **TeX Live 2025** | `alpine/Dockerfile`: `TL_SNAPSHOT=systems/texlive/2025/tlnet-final`（凍結スナップショット） |
| latex-release-action `v3.3.0` | `v3.5.0` | リリース済み |
| 更新頻度「年次(TeXLive リリース)」 | 随時 | 2026a(06-05) → 2026b(07-29) → 2026c(07-30) → 2026d(08-04) |

`2026x` はイメージ側のリリース系列であって TeX Live の版ではない、という点が表に反映されておらず、「TeXLive 2026 を使っている」と読める状態だった。TeX Live 2026 への移行は texlive-ja-textlint#96 で未決である。

## 変更内容

- 表の 3 行を実体に合わせる
- タグ戦略のカレンダーバージョニングの説明に、年がイメージのリリース系列であることを 1 文追記する（今回の誤りの再発防止）
- 例を `2025b` → `2026d` に更新し、Last Updated を更新する

## 補足

この表は他所にある状態を写したもので、構造的に陳腐化する。乖離を検出する仕組みは smkwlab/.github#128 で扱う。
