### PR TITLE
docs: correct the CI build image tag to the shipped 2026d

### DIFF
--- a/docs/MULTI-ORG-DEPLOYMENT.md
+++ b/docs/MULTI-ORG-DEPLOYMENT.md
@@ -229,7 +229,7 @@ org — 独立性、エアギャップ、または再利用可能ロジックそ
   `ALDC_REPOSITORY_NAME` 環境変数で向ける
   （[aldc#32](https://github.com/smkwlab/aldc/issues/32)）。
 - **CI ビルドイメージ** — `latex-build-modified.yml` は
-  `container: ghcr.io/smkwlab/texlive-ja-textlint:2026a` で *同じ* イメージと
+  `container: ghcr.io/smkwlab/texlive-ja-textlint:2026d` で *同じ* イメージと
   タグを固定します（PDF ビルドが開発環境を再現するよう、意図的に DevContainer に
   一致させている）。一方 `latex-build.yml` は `smkwlab/latex-release-action` を
   通じて間接的にイメージに到達します。どちらも `smkwlab/.github` にあるため、


### PR DESCRIPTION
## 背景

`docs/MULTI-ORG-DEPLOYMENT.md` が「`latex-build-modified.yml` は `container: ghcr.io/smkwlab/texlive-ja-textlint:2026a` でイメージとタグを固定する」と書いているが、実際は `2026d` である。

これは例示ではなく**現状を述べた記述**なので、そのまま事実として誤っている。他 org へ展開する人が、向け直すべき箇所の値を確認するために読む箇所でもある。

```
$ gh api repos/smkwlab/.github/contents/.github/workflows/latex-build-modified.yml?ref=v1 \
    --jq .content | base64 -d | grep -n container:
57:    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
```

## 変更内容

タグを `2026a` → `2026d` に修正する。この段落の主張（DevContainer と同じイメージ・タグを意図的に固定している）は変わらない。

## 検出経緯

smkwlab/.github#131 で入れたタグ監査（[run 30887471373](https://github.com/smkwlab/.github/actions/runs/30887471373)）が検出した 3 箇所のうち 1 箇所。残る 2 箇所（aldc `docs/CLAUDE-USAGE.md`）は smkwlab/aldc#35 で是正する。両方入れば smkwlab/.github#132 は解消する。
