### PR TITLE
docs: bring the templates under the Renovate policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,13 @@ Use the **`/propagate` skill** ([.claude/skills/propagate/SKILL.md](.claude/skil
 
 ### 依存管理基盤（Renovate 一本化）
 
-Dependency updates for the development infrastructure repositories are handled by Renovate; Dependabot is not used. Shared presets live in `smkwlab/.github` and are referenced through the moving `v1` tag.
+Dependency updates for the development infrastructure repositories and the document templates are handled by Renovate; Dependabot is not used. Shared presets live in `smkwlab/.github` and are referenced through the moving `v1` tag.
 
 The governing principle is that **Renovate checks and Renovate merges** — GitHub's auto-merge releases a merge as soon as branch protection is satisfied, which on a repository with no required status checks means before CI has run. Renovate waits for every check run on the PR instead, so the decision does not depend on repository settings. Branch protection is the floor for human merges, not the condition for automated ones.
 
 Auto-merge covers grouped minor/patch/digest updates; major updates always get individual review. Automated merges reach `main` only — publishing a Docker image tag, moving `v1`, and cutting a release stay manual.
 
-Student repositories have no Renovate, so they must reach infrastructure through a shared workflow rather than referencing it directly: a pin nobody can bump never moves again, and the reference still resolves, so nothing fails to signal it.
+Student repositories have no Renovate, so they must reach infrastructure through a shared workflow rather than referencing it directly: a pin nobody can bump never moves again, and the reference still resolves, so nothing fails to signal it. Templates carry the same constraint because their contents are copied into every repository generated from them, which is why they use the `:template` preset instead of `:latex` and keep the shared-workflow reference unpinned.
 
 See [docs/DEPENDENCY-MANAGEMENT.md](docs/DEPENDENCY-MANAGEMENT.md) for the preset layout, reference modes, per-repository required status checks, and the invariants to preserve when changing any of it.
 

--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -1,6 +1,6 @@
 # 依存管理基盤（Renovate 一本化）
 
-開発インフラリポジトリの依存関係更新は Renovate に一元化しています（Dependabot は不使用）。本書はその方針と設定の所在をまとめたものです。
+開発インフラリポジトリとドキュメントテンプレートの依存関係更新は Renovate に一元化しています（Dependabot は不使用）。本書はその方針と設定の所在をまとめたものです。
 
 手動でのイメージ再ビルドとテンプレートへの伝播は [RELEASE-OPERATIONS.md](RELEASE-OPERATIONS.md) を参照してください。学生リポジトリには Renovate を導入しておらず、draft PR サイクルとは無関係です。
 
@@ -32,6 +32,7 @@
 | `npm.json` | `:npm` | npm の minor/patch/digest/lockFileMaintenance をグループ `npm dependencies` にまとめて自動マージ |
 | `elixir.json` | `:elixir` | default + `:github-actions` を extends。mix(hex) の minor まで自動マージ（org 全体の patch/digest 限定方針に対する意図的な例外） |
 | `latex.json` | `:latex` | default + `:github-actions` + `:npm` を extends。スケジュール・流量・pin 方針と `lockFileMaintenance` を担当 |
+| `template.json` | `:template` | `:latex` を extends。テンプレート専用に、共有ワークフロー参照の digest 固定だけを外す |
 
 major はどの preset でも自動マージ対象外。
 
@@ -40,8 +41,13 @@ major はどの preset でも自動マージ対象外。
 | リポジトリ | 参照 |
 |---|---|
 | texlive-ja-textlint / latex-environment / latex-release-action / ai-academic-paper-reviewer / student-repo-management | `:latex#v1` |
+| sotsuron-template / sotsuron-report-template / ise-report-template / wr-template / latex-template / poster-template | `:template#v1` |
 | tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap | `:elixir#v1` |
 | .github | `default` + `:github-actions`（`enabledManagers` は github-actions のみ） |
+
+テンプレートが `:latex` をそのまま参照しないのは、**テンプレートの内容が学生リポジトリへそのままコピーされる**ため。`:latex` は github-actions の参照を digest 固定するが、学生リポジトリには Renovate が居ないので、固定された参照はそこで永久に凍結する。これは[参照方式](#参照方式)の層 3 が守っている性質にあたる。サードパーティ action は実在するバージョンを指しており凍結しても無害なので、SHA 固定のままにしている。
+
+学生リポジトリ自体は Renovate の対象外で、生成時に `.github/renovate.json` を削除する（`dependabot.yml` と同じ扱い）。
 
 `.github` は `:latex` を extends していない。preset の変更で latex 系だけを対象にすると `.github` が漏れるため、org 全体に効かせたい設定は `default.json` に置く。
 
@@ -144,3 +150,5 @@ required に指定してよいのは、**その PR で必ず check run が生成
 - 自動マージが到達するのは `main` まで。配布は人間の明示操作
 - 参照方式は [参照方式](#参照方式) の 4 層に従う。とくに、移動タグを見る消費者は開発インフラ層を直接参照しない
 - 脆弱性の検知はリポジトリ設定に依存させない。`osvVulnerabilityAlerts` を無効に戻すなら、Dependabot alerts が全リポジトリで有効であることを別の手段で保証すること
+- テンプレートは `:template` を参照する。`:latex` に切り替えるなら、共有ワークフロー参照が digest 固定されて学生リポジトリで凍結しないことを別の手段で保証すること
+- 学生リポジトリに依存更新の設定を残さない。生成時に `dependabot.yml` と `renovate.json` を削除する

--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -45,7 +45,7 @@ major はどの preset でも自動マージ対象外。
 | tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap | `:elixir#v1` |
 | .github | `default` + `:github-actions`（`enabledManagers` は github-actions のみ） |
 
-テンプレートが `:latex` をそのまま参照しないのは、**テンプレートの内容が学生リポジトリへそのままコピーされる**ため。`:latex` は github-actions の参照を digest 固定するが、学生リポジトリには Renovate が居ないので、固定された参照はそこで永久に凍結する。これは[参照方式](#参照方式)の層 3 が守っている性質にあたる。サードパーティ action は実在するバージョンを指しており凍結しても無害なので、SHA 固定のままにしている。
+テンプレートが `:latex` をそのまま参照しないのは、**テンプレートの内容が学生リポジトリへそのままコピーされる**ため。`:latex` は github-actions の参照を digest 固定するが、学生リポジトリには Renovate が居ないので、固定された参照はそこで永久に凍結する。これは[参照方式](#参照方式)の層 3 が守っている性質にあたる。サードパーティ action は SHA 固定のままにしている。学生リポジトリではこれも凍結するため、脆弱性が見つかっても古いまま残るというトレードオフを受け入れている。固定を外せば凍結は避けられるが、可変タグを学生リポジトリに配ることになり、そちらの危険の方が大きい。
 
 学生リポジトリ自体は Renovate の対象外で、生成時に `.github/renovate.json` を削除する（`dependabot.yml` と同じ扱い）。
 


### PR DESCRIPTION
## 背景

依存管理が Dependabot（テンプレート）と Renovate（インフラ）に二分しており、方針文書は Renovate 一本を明示していた。テンプレート 6 リポジトリを Renovate に移したので、文書を実体に合わせる。

移行の実体（マージ済み）:

| 変更 | PR |
|---|---|
| テンプレート用 preset `:template` の追加（v1.34.0 で配布） | smkwlab/.github#134 |
| テンプレート 6 つの `dependabot.yml` → `renovate.json` | sotsuron#147 / sotsuron-report#34 / ise-report#105 / wr#59 / latex#58 / poster#34 |
| 生成時に `renovate.json` も削除 | smkwlab/student-repo-management#579（レビュー中） |

## 変更内容

### `docs/DEPENDENCY-MANAGEMENT.md`

- 冒頭の対象範囲に「ドキュメントテンプレート」を追加
- preset 構成表に `template.json` の行を追加
- 参照先の表にテンプレート 6 リポジトリの行を追加
- **なぜテンプレートが `:latex` を直接参照しないのか**を説明する段落を追加。テンプレートの内容は学生リポジトリへそのままコピーされ、学生側には Renovate が居ないため、`:latex` の digest 固定がそこで永久に凍結する。参照方式の層 3 が守っている性質にあたる
- 不変条件に 2 行追加（テンプレートは `:template` を参照する／学生リポジトリに依存更新の設定を残さない）

### `CLAUDE.md`

依存管理の節が「開発インフラリポジトリ」だけを対象に書いていたので、テンプレートを含む記述に直した。テンプレートが `:template` を使う理由も 1 文添えている。

## 補足

`ECOSYSTEM.md` には Dependabot / Renovate に触れた記述が無く、追随は不要だった。

Resolves #159
