### PR TITLE
docs: disable GitHub auto-merge across every repository

### DIFF
--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -164,7 +164,7 @@ required に指定してよいのは、**その PR で必ず check run が生成
 
 変更する場合は本書も更新すること。
 
-- `allow_auto_merge` は全リポジトリで無効。GitHub の auto-merge はブランチ保護の要件が満たされた時点でマージするため、required に入っていない check（elixir 系の `security / …` など）を待たない。マージは Renovate 自前の automerge に任せる
+- `allow_auto_merge` は全リポジトリで無効。GitHub の auto-merge はブランチ保護の要件が満たされた時点でマージするため、required に入っていない check を待たない（elixir 系では `security / Secret Scanning` と `security / Dependency Security Audit` がこれにあたる）。マージは Renovate 自前の automerge に任せる
 - `platformAutomerge` は org 既定 false で、opt-in しているリポジトリは無い。opt-in する場合は、ブランチ保護が自リポジトリの CI 全体を表現できていることを確認する
 - `enforce_admins: false` は全リポジトリ共通。`strict: false` は latex 系のみ（elixir 系は true）
 - テストマトリクスは集約ジョブ 1 つで required にする。集約ジョブから `if: always()` を外さないこと（skip は通過扱いになるため、外すと止めるべきときに緑になる）

--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -143,7 +143,7 @@ Dependabot 自身の自動 PR（`automated-security-fixes`）は全リポジト�
 | .github | `actionlint` |
 | tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap | `ci / Code Quality`, `ci / All checks` |
 
-elixir 系 5 リポジトリは `strict: true`、`allow_auto_merge` は有効。この 2 つが latex 系との違いで、`enforce_admins` は揃えてある。`strict` は 1 本マージするたびに全 PR が rebase と再ビルドになるため latex 系では false にしているが、elixir 系は grouped PR が実質 2 本（`elixir dependencies` / `github actions`）で問題が出ていない。
+latex 系との違いは `strict` だけで、elixir 系は true。1 本マージするたびに全 PR が rebase と再ビルドになるため latex 系では false にしているが、elixir 系はマージが月 0〜4 件・open PR が 0〜2 件で、その費用が発生していない。引き換えに得ているのは、個別には緑でも組み合わせると壊れる PR の検出で、これを防ぐ仕組みは他に無い。流量が増えたら latex 系と同じ判断になる。
 
 ### マトリクスは集約ジョブ 1 つで受ける
 
@@ -164,7 +164,7 @@ required に指定してよいのは、**その PR で必ず check run が生成
 
 変更する場合は本書も更新すること。
 
-- `allow_auto_merge` は latex 系の 6 リポジトリ（`:latex#v1` を参照する 5 つと `.github`）で無効。elixir 系 5 リポジトリでは有効
+- `allow_auto_merge` は全リポジトリで無効。GitHub の auto-merge はブランチ保護の要件が満たされた時点でマージするため、required に入っていない check（elixir 系の `security / …` など）を待たない。マージは Renovate 自前の automerge に任せる
 - `platformAutomerge` は org 既定 false で、opt-in しているリポジトリは無い。opt-in する場合は、ブランチ保護が自リポジトリの CI 全体を表現できていることを確認する
 - `enforce_admins: false` は全リポジトリ共通。`strict: false` は latex 系のみ（elixir 系は true）
 - テストマトリクスは集約ジョブ 1 つで required にする。集約ジョブから `if: always()` を外さないこと（skip は通過扱いになるため、外すと止めるべきときに緑になる）


### PR DESCRIPTION
## 背景

elixir 系 5 リポジトリの `allow_auto_merge` を無効にした。これで **org 全 11 リポジトリで無効**になり、原則 2「マージの実行主体は Renovate bot。判定条件はリポジトリ設定に依存しない」が例外なく成立する。

### 実害があった

調べたところ、**GitHub の auto-merge が armed になった PR が 2 件あった**。

| PR | 有効化した主体 | 日付 |
|---|---|---|
| tenbin_dns#132 | **app/renovate** | 2026-07-19 |
| tenbin_cache#128 | **app/renovate** | 2026-07-19 |

`platformAutomerge: false` は 2026-08-03（v1.29.0）なので、それ以前に Renovate が有効化したものが残っていた。GitHub の auto-merge は**ブランチ保護の要件が満たされた時点**でマージするため、この 2 件は smkwlab/.github#117 で `ci / All checks` を required に入れるまで、**テストマトリクスの完了を待たずにマージされうる状態**だった。止めていたのは `strict: true` による BEHIND 状態で、意図した安全装置ではない。

2 件とも auto-merge を解除したうえで、リポジトリ設定を無効にした。

### required は今も CI 全体を表現していない

`security.yml` が生成する `security / Secret Scanning` と `security / Dependency Security Audit` は required に入っていない。GitHub の auto-merge はこれらを待たないが、Renovate 自前の automerge は PR の全 check run を待つ。**この差が原則 2 の根拠そのもの**なので、弱い経路を残す理由が無い。

## 変更内容

- 不変条件の `allow_auto_merge` の行を「全リポジトリで無効」に変更し、なぜ無効にするのか（required に入っていない check を待たない）を明記
- required status checks の節で、latex 系との違いが `strict` だけになったことを反映

### `strict` は据え置き

elixir 系は `strict: true` のまま。latex 系で false にしたのは「1 本マージするたびに全 PR が rebase と再ビルドになる」実害があったからだが、**elixir 系ではマージが月 0〜4 件・open PR が 0〜2 件でその費用が発生していない**。引き換えに得ている「個別には緑でも組み合わせると壊れる PR の検出」は他に代替が無いため、値が違う理由ごと文書に残した。

## 検証

5 リポジトリすべてで、他のマージ設定（squash / merge / rebase / delete_branch）とブランチ保護（contexts / `strict` / `enforce_admins`）が未変更であることを確認済み。armed な auto-merge も 0 件。

ref: smkwlab/.github#117
