### PR TITLE
chore(renovate): put this repository under the latex preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>smkwlab/.github:latex#v1"]
+}

--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -47,9 +47,9 @@ major はどの preset でも自動マージ対象外。
 
 | リポジトリ | 参照 |
 |---|---|
-| texlive-ja-textlint / latex-environment / latex-release-action / ai-academic-paper-reviewer / student-repo-management | `:latex#v1` |
+| texlive-ja-textlint / latex-environment / latex-release-action / ai-academic-paper-reviewer / student-repo-management / latex-ecosystem | `:latex#v1` |
 | sotsuron-template / sotsuron-report-template / ise-report-template / wr-template / latex-template / poster-template | `:template#v1` |
-| tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap | `:elixir#v1` |
+| tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap / ecosystem-manager / registry-manager / thesis-monitor / elixir-tool-kit | `:elixir#v1` |
 | .github | `default` + `:github-actions`（`enabledManagers` は github-actions のみ） |
 
 テンプレートが `:latex` をそのまま参照しないのは、**テンプレートの内容が学生リポジトリへそのままコピーされる**ため。
@@ -60,6 +60,9 @@ major はどの preset でも自動マージ対象外。
 固定を外せば凍結は避けられるが、可変タグを学生リポジトリに配ることになり、そちらの危険の方が大きい。
 
 学生リポジトリ自体は Renovate の対象外で、生成時に `.github/renovate.json` を削除する（`dependabot.yml` と同じ扱い）。
+
+aldc と thesis-student-registry も対象外。
+ワークフローが共有ワークフローを移動タグで呼ぶだけで、Renovate が更新できる依存を 1 つも持たない。
 
 `.github` は `:latex` を extends していない。
 preset の変更で latex 系だけを対象にすると `.github` が漏れるため、org 全体に効かせたい設定は `default.json` に置く。


### PR DESCRIPTION
## 問題

このリポジトリは Renovate の方針を文書化している当のリポジトリでありながら、その対象に入っていなかった。

結果は自分のワークフローに出ている。`update-dashboard.yml` が **`actions/checkout@v4`** を参照している — SHA 固定なし、メジャー 2 つ遅れ。エコシステム内の他は `actions/checkout@3d3c42e5… # v7.0.1` で揃っている。

docs/DEPENDENCY-MANAGEMENT.md は「サードパーティ action は SHA 固定 + バージョンコメント、更新主体は Renovate」と書いているが、その Renovate が居なかった。

## 変更

### 1. `.github/renovate.json` の追加

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:latex#v1"]
}
```

`.github` と同じ `default` + `:github-actions` ではなく `:latex` を参照する。ここでは違いが効く。

| | `default` + `:github-actions` | `:latex` |
|---|---|---|
| github-actions の digest 固定 | 行わない | **行う**（`actions/checkout@v4` が SHA 固定される） |
| `smkwlab/.github` 参照 | 固定対象になる | **例外として移動タグのまま** |

`ai-code-review.yml` は `smkwlab/.github/.github/workflows/ai-review.yml@v1` を呼んでおり、これは文書が「固定してはならない」と説明している参照にあたる。`:latex` はその例外規則を持っているが、素の `:github-actions` は持たない。

`:latex` が併せて持ち込む npm と `lockFileMaintenance` の規則は、どちらも存在しないこのリポジトリでは no-op。

### 2. 参照先テーブルの更新

`:latex#v1` の行に latex-ecosystem を追加。併せて `:elixir#v1` の行に Elixir ツール 4 本を追加した。同じ 1 行の設定を各リポジトリ側で入れる PR を出しているため、それらがマージされた時点でテーブルが誤りになる。

- smkwlab/ecosystem-manager#21
- smkwlab/registry-manager#89
- smkwlab/thesis-monitor#69
- smkwlab/elixir-tool-kit#17

### 3. 対象外リポジトリの明記

aldc と thesis-student-registry を対象外として書いた。どちらもワークフローが 1 本で、その依存は移動タグの共有ワークフローだけなので、Renovate に更新するものが無い。書かずに省くと、この PR が直しているのと同じ見落としに見えてしまう。

## 補足

ファイルの commit だけでは動かない。Renovate App のインストール対象への追加が必要で、そちらは #174 で追跡している。
