### PR TITLE
docs: describe this ecosystem, not the DNS project

### DIFF
--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -189,7 +189,7 @@ Dependabot 自身の自動 PR（`automated-security-fixes`）は全リポジト�
 
 自動マージの条件ではなく、人手マージの床。
 `enforce_admins: false` は全リポジトリ共通（CI が壊れた緊急時に管理者が明示的に突破できる。Renovate App はブランチ保護をバイパスしないため bot 側は必ずゲートされる）。
-`strict: false`（up-to-date 要求なし）は latex 系のみ。
+`strict: false`（up-to-date 要求なし）は、保護を設定している全リポジトリで共通。
 
 | リポジトリ | contexts |
 |---|---|
@@ -199,12 +199,15 @@ Dependabot 自身の自動 PR（`automated-security-fixes`）は全リポジト�
 | ai-academic-paper-reviewer | `test` |
 | student-repo-management | `Validate YAML files` |
 | .github | `actionlint` |
-| tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap | `ci / Code Quality`, `ci / All checks` |
+| ecosystem-manager / registry-manager / thesis-monitor / elixir-tool-kit | 未設定 |
 
-latex 系との違いは `strict` だけで、elixir 系は true。
-1 本マージするたびに全 PR が rebase と再ビルドになるため latex 系では false にしているが、elixir 系はマージが月 0〜4 件・open PR が 0〜2 件で、その費用が発生していない。
-引き換えに得ているのは、個別には緑でも組み合わせると壊れる PR の検出で、これを防ぐ仕組みは他に無い。
-流量が増えたら latex 系と同じ判断になる。
+elixir 系に設定する場合の contexts は `ci / Code Quality` と `ci / All checks` の 2 つ。
+どちらも共有ワークフロー `elixir-ci.yml` のジョブなので、リポジトリごとに違う名前になることはない。
+
+`strict`（マージ前に main を取り込むことの要求）は latex 系では false にしている。
+1 本マージするたびに全 PR が rebase と再ビルドになるためで、流量が少なければこの費用は発生しない。
+true で得られるのは、個別には緑でも組み合わせると壊れる PR の検出で、これを防ぐ仕組みは他に無い。
+流量の少ないリポジトリでは true を選ぶ余地がある。
 
 ### マトリクスは集約ジョブ 1 つで受ける
 
@@ -234,12 +237,12 @@ required に指定してよいのは、**その PR で必ず check run が生成
 変更する場合は本書も更新すること。
 
 - `allow_auto_merge` は全リポジトリで無効。
-  GitHub の auto-merge はブランチ保護の要件が満たされた時点でマージするため、required に入っていない check を待たない（elixir 系では `security / Secret Scanning` と `security / Dependency Security Audit` がこれにあたる）。
+  GitHub の auto-merge はブランチ保護の要件が満たされた時点でマージするため、required に入っていない check（`review / review` など）を待たない。
   マージは Renovate 自前の automerge に任せる
 - `platformAutomerge` は org 既定 false で、opt-in しているリポジトリは無い。
   opt-in する場合は、ブランチ保護が自リポジトリの CI 全体を表現できていることを確認する
 - `enforce_admins: false` は全リポジトリ共通。
-  `strict: false` は latex 系のみ（elixir 系は true）
+  `strict: false` も保護を設定している全リポジトリで共通
 - テストマトリクスは集約ジョブ 1 つで required にする。
   集約ジョブから `if: always()` を外さないこと（skip は通過扱いになるため、外すと止めるべきときに緑になる）
 - 自動マージが到達するのは `main` まで。

--- a/docs/DEPENDENCY-MANAGEMENT.md
+++ b/docs/DEPENDENCY-MANAGEMENT.md
@@ -49,7 +49,7 @@ major はどの preset でも自動マージ対象外。
 |---|---|
 | texlive-ja-textlint / latex-environment / latex-release-action / ai-academic-paper-reviewer / student-repo-management / latex-ecosystem | `:latex#v1` |
 | sotsuron-template / sotsuron-report-template / ise-report-template / wr-template / latex-template / poster-template | `:template#v1` |
-| tenbin_dns / tdig / tenbin_ex / tenbin_cache / elixir_dnstap / ecosystem-manager / registry-manager / thesis-monitor / elixir-tool-kit | `:elixir#v1` |
+| ecosystem-manager / registry-manager / thesis-monitor / elixir-tool-kit | `:elixir#v1` |
 | .github | `default` + `:github-actions`（`enabledManagers` は github-actions のみ） |
 
 テンプレートが `:latex` をそのまま参照しないのは、**テンプレートの内容が学生リポジトリへそのままコピーされる**ため。


### PR DESCRIPTION
## 問題

この文書は 2 箇所で **DNS 研究プロジェクトのリポジトリ**（`tenbin_dns` / `tdig` / `tenbin_ex` / `tenbin_cache` / `elixir_dnstap`）を記述していた。このエコシステムとは org と `:elixir` preset を共有しているだけで、それ以外の接点が無い。

読者がこれらに出会う理由が無いうえ、出会った読者には**周囲の記述がどちらのファミリを指しているのか判別できない**。

### 1. 参照先テーブル

エコシステム自身の Elixir ツール 4 本と、無関係な 5 本が同じ行に並んでいた。

### 2. required status checks

こちらはより深刻で、**elixir に関する記述が丸ごと別プロジェクトのものだった**。

- 行を構成するのは DNS の 5 本だけ
- `strict` を true にする根拠は、そこで計測した流量（マージが月 0〜4 件・open PR が 0〜2 件）
- auto-merge が待たない check の例も、そこの security ワークフロー

エコシステムの Elixir ツール 4 本は 1 つも言及されておらず、しかも**4 本ともブランチ保護が設定されていない**。

```
ecosystem-manager    Branch not protected
registry-manager     Branch not protected
thesis-monitor       Branch not protected
elixir-tool-kit      Branch not protected
```

## 変更

**elixir を除外するのではない。** `elixir-ci.yml` は共有ワークフローで、このエコシステムのツール 4 本が使っている。その知見は呼び出す側が誰であっても成立するため、すべて残した。

- `ci / Code Quality` と `ci / All checks` という 2 つの context 名
- 版名を含むテストマトリクスを集約ジョブ 1 つで受ける理由
- 集約ジョブに `if: always()` が要る理由（skip が通過扱いになるため）

置き換えたのは、DNS のリポジトリでしか成り立たない記述だけ。

| 箇所 | 変更 |
|---|---|
| 参照先テーブル | DNS の 5 本を削除。エコシステムの 4 本を残す |
| contexts テーブル | DNS の行を、エコシステムの 4 本と**実際の状態（未設定）**に置換 |
| `strict` の根拠 | DNS の流量ではなく、latex 系で false にしている理由と、true を選ぶ余地の説明に |
| `strict: false` は latex 系のみ | 保護を設定している全 6 リポジトリが `strict: false` であることを実測のうえ記載 |
| auto-merge が待たない check の例 | DNS の security ワークフローから `review / review` に |

## 別途対応が必要なこと

**エコシステムの Elixir ツール 4 本にブランチ保護が無い。** 文書上は「未設定」と現状どおり書いたが、これは新設リポジトリで設定が漏れているだけと思われる。別 Issue で扱うべき案件。
